### PR TITLE
`TrackingQuery` cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ php:
     - nightly
     - 8.0
     - 7.4
-    - 7.3
 
 before_script:
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to `tracking` will be documented in this file
 - fix issue with `TrackTraffic` model not passing value to attribute setter in `TrackTrafficObserver`
 
 
-## 0.2.1 - 2021-04-14
+## 0.3.0 - 2021-04-14
+- cut support for php7.4
 - cut relationships brought in from hpa app in `TrackingQuery`
 - fix $parameters param to default as null in `TrackingQuery`
 - start making query test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,9 @@ All notable changes to `tracking` will be documented in this file
 - fix use of sfneal/string-helpers helper functions by adding import of `StringHelpers`
 - fix issue with `TrackTrafficObserver` not being attached to `TrackTraffic` model
 - fix issue with `TrackTraffic` model not passing value to attribute setter in `TrackTrafficObserver`
+
+
+## 0.2.1 - 2021-04-14
+- cut relationships brought in from hpa app in `TrackingQuery`
+- fix $parameters param to default as null in `TrackingQuery`
+- start making query test suite

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-json": "*",
         "jenssegers/agent": "^2.6",
         "sfneal/actions": "^2.0",

--- a/src/Queries/Base/TrackingQuery.php
+++ b/src/Queries/Base/TrackingQuery.php
@@ -25,13 +25,13 @@ abstract class TrackingQuery extends Query
     /**
      * TrackActionQuery constructor.
      * @param Request|null $request
-     * @param array        $parameters
+     * @param array|null   $parameters
      * @param array|null   $relationships
      */
-    public function __construct(Request $request = null, array $parameters = [], array $relationships = null)
+    public function __construct(Request $request = null, array $parameters = null, array $relationships = null)
     {
         $this->request = $request;
-        $this->parameters = $parameters;
+        $this->parameters = $parameters ?? [];
         $this->relationships = $relationships;
     }
 }

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Tracking\Queries;
 
-use Illuminate\Database\Eloquent\Builder;
 use Sfneal\Helpers\Time\TimePeriods;
 use Sfneal\Queries\Traits\ParamGetter;
 use Sfneal\Tracking\Builders\TrackActionBuilder;
@@ -18,7 +17,7 @@ class TrackActionQuery extends TrackingQuery
     /**
      * Retrieve a Query builder.
      *
-     * @return TrackActionBuilder|Builder
+     * @return TrackActionBuilder
      */
     protected function builder(): TrackActionBuilder
     {

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -10,6 +10,8 @@ use Sfneal\Tracking\Queries\Base\TrackingQuery;
 
 class TrackActionQuery extends TrackingQuery
 {
+    // todo: add request validation
+
     use ParamGetter;
 
     /**

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -15,29 +15,19 @@ class TrackActionQuery extends TrackingQuery
     use ParamGetter;
 
     /**
-     * Relationships that should be eager loaded by default.
-     */
-    private const DEFAULT_RELATIONSHIPS = [
-        'plan',
-        'planManagement',
-        'planManagement.plan',
-        'project',
-        'task',
-        'task.project',
-        'taskRecord',
-        'taskRecord.task',
-        'taskRecord.task.project',
-    ];
-
-    /**
      * Retrieve a Query builder.
      *
      * @return TrackActionBuilder
      */
     protected function builder(): TrackActionBuilder
     {
-        return TrackAction::query()
-            ->with($this->relationships ?? self::DEFAULT_RELATIONSHIPS);
+        $builder = TrackAction::query();
+
+        if ($this->relationships) {
+            $builder->with($this->relationships);
+        }
+
+        return $builder;
     }
 
     /**

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Tracking\Queries;
 
+use Illuminate\Database\Eloquent\Builder;
 use Sfneal\Helpers\Time\TimePeriods;
 use Sfneal\Queries\Traits\ParamGetter;
 use Sfneal\Tracking\Builders\TrackActionBuilder;
@@ -17,7 +18,7 @@ class TrackActionQuery extends TrackingQuery
     /**
      * Retrieve a Query builder.
      *
-     * @return TrackActionBuilder
+     * @return TrackActionBuilder|Builder
      */
     protected function builder(): TrackActionBuilder
     {

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -10,6 +10,8 @@ use Sfneal\Tracking\Queries\Base\TrackingQuery;
 
 class TrackActivityQuery extends TrackingQuery
 {
+    // todo: add request validation
+
     use ParamGetter;
 
     /**

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Tracking\Queries;
 
-use Illuminate\Database\Eloquent\Builder;
 use Sfneal\Helpers\Time\TimePeriods;
 use Sfneal\Queries\Traits\ParamGetter;
 use Sfneal\Tracking\Builders\TrackActivityBuilder;
@@ -35,7 +34,7 @@ class TrackActivityQuery extends TrackingQuery
     /**
      * Retrieve a Query builder.
      *
-     * @return TrackActivityBuilder|Builder
+     * @return TrackActivityBuilder
      */
     protected function builder(): TrackActivityBuilder
     {

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Tracking\Queries;
 
+use Illuminate\Database\Eloquent\Builder;
 use Sfneal\Helpers\Time\TimePeriods;
 use Sfneal\Queries\Traits\ParamGetter;
 use Sfneal\Tracking\Builders\TrackActivityBuilder;
@@ -34,7 +35,7 @@ class TrackActivityQuery extends TrackingQuery
     /**
      * Retrieve a Query builder.
      *
-     * @return TrackActivityBuilder
+     * @return TrackActivityBuilder|Builder
      */
     protected function builder(): TrackActivityBuilder
     {

--- a/tests/Feature/Builders/TrackActionBuilderTest.php
+++ b/tests/Feature/Builders/TrackActionBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Sfneal\Tracking\Tests\Feature\Builders;
 
 use Sfneal\Tracking\Models\TrackAction;
-use Sfneal\Tracking\Tests\Feature\Builders\Traits\WhereModelTests;
 
 class TrackActionBuilderTest extends BuilderTestCase
 {

--- a/tests/Feature/Builders/TrackActivityBuilderTest.php
+++ b/tests/Feature/Builders/TrackActivityBuilderTest.php
@@ -3,8 +3,6 @@
 namespace Sfneal\Tracking\Tests\Feature\Builders;
 
 use Sfneal\Tracking\Models\TrackActivity;
-use Sfneal\Tracking\Tests\Feature\Builders\Traits\WhereModelTests;
-use Sfneal\Tracking\Tests\Feature\Builders\Traits\WhereUserTests;
 
 class TrackActivityBuilderTest extends BuilderTestCase
 {

--- a/tests/Feature/Builders/TrackTrafficBuilderTest.php
+++ b/tests/Feature/Builders/TrackTrafficBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Sfneal\Tracking\Tests\Feature\Builders;
 
 use Sfneal\Tracking\Models\TrackTraffic;
-use Sfneal\Tracking\Tests\Feature\Builders\Traits\WhereUserTests;
 
 class TrackTrafficBuilderTest extends BuilderTestCase
 {

--- a/tests/Feature/Builders/WhereModelTests.php
+++ b/tests/Feature/Builders/WhereModelTests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Tracking\Tests\Feature\Builders\Traits;
+namespace Sfneal\Tracking\Tests\Feature\Builders;
 
 trait WhereModelTests
 {

--- a/tests/Feature/Builders/WhereUserTests.php
+++ b/tests/Feature/Builders/WhereUserTests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Tracking\Tests\Feature\Builders\Traits;
+namespace Sfneal\Tracking\Tests\Feature\Builders;
 
 trait WhereUserTests
 {

--- a/tests/Feature/Factories/FactoryAttributesTest.php
+++ b/tests/Feature/Factories/FactoryAttributesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Tracking\Tests\Feature\Factories\Interfaces;
+namespace Sfneal\Tracking\Tests\Feature\Factories;
 
 // todo: consider moving to sfneal/mock-models?
 interface FactoryAttributesTest

--- a/tests/Feature/Factories/FactoryFillablesTest.php
+++ b/tests/Feature/Factories/FactoryFillablesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Tracking\Tests\Feature\Factories\Interfaces;
+namespace Sfneal\Tracking\Tests\Feature\Factories;
 
 // todo: consider moving to sfneal/mock-models?
 interface FactoryFillablesTest

--- a/tests/Feature/Factories/TrackActionFactoryTest.php
+++ b/tests/Feature/Factories/TrackActionFactoryTest.php
@@ -3,7 +3,6 @@
 namespace Sfneal\Tracking\Tests\Feature\Factories;
 
 use Sfneal\Tracking\Models\TrackAction;
-use Sfneal\Tracking\Tests\Feature\Factories\Interfaces\FactoryFillablesTest;
 
 class TrackActionFactoryTest extends FactoriesTestCase implements FactoryFillablesTest
 {

--- a/tests/Feature/Factories/TrackActivityFactoryTest.php
+++ b/tests/Feature/Factories/TrackActivityFactoryTest.php
@@ -3,7 +3,6 @@
 namespace Sfneal\Tracking\Tests\Feature\Factories;
 
 use Sfneal\Tracking\Models\TrackActivity;
-use Sfneal\Tracking\Tests\Feature\Factories\Interfaces\FactoryFillablesTest;
 
 class TrackActivityFactoryTest extends FactoriesTestCase implements FactoryFillablesTest
 {

--- a/tests/Feature/Factories/TrackTrafficFactoryTest.php
+++ b/tests/Feature/Factories/TrackTrafficFactoryTest.php
@@ -3,7 +3,6 @@
 namespace Sfneal\Tracking\Tests\Feature\Factories;
 
 use Sfneal\Tracking\Models\TrackTraffic;
-use Sfneal\Tracking\Tests\Feature\Factories\Interfaces\FactoryFillablesTest;
 
 class TrackTrafficFactoryTest extends FactoriesTestCase implements FactoryFillablesTest
 {

--- a/tests/Feature/Queries/QueriesTestCase.php
+++ b/tests/Feature/Queries/QueriesTestCase.php
@@ -21,6 +21,11 @@ class QueriesTestCase extends TestCase
     public $models;
 
     /**
+     * @var int
+     */
+    public $count = 1000;
+
+    /**
      * Setup the test environment.
      *
      * @return void
@@ -30,6 +35,6 @@ class QueriesTestCase extends TestCase
         parent::setUp();
 
         // Retrieve the People model from an Address model
-        $this->models = $this->modelClass::factory()->count(1000)->create();
+        $this->models = $this->modelClass::factory()->count($this->count)->create();
     }
 }

--- a/tests/Feature/Queries/QueriesTestCase.php
+++ b/tests/Feature/Queries/QueriesTestCase.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Tests\Feature\Queries;
-
 
 use Illuminate\Support\Collection;
 use Sfneal\Tracking\Models\Base\Tracking;

--- a/tests/Feature/Queries/QueriesTestCase.php
+++ b/tests/Feature/Queries/QueriesTestCase.php
@@ -1,9 +1,35 @@
 <?php
 
+
 namespace Sfneal\Tracking\Tests\Feature\Queries;
 
+
+use Illuminate\Support\Collection;
+use Sfneal\Tracking\Models\Base\Tracking;
 use Sfneal\Tracking\Tests\TestCase;
 
 class QueriesTestCase extends TestCase
 {
+    /**
+     * @var Tracking
+     */
+    public $modelClass = Tracking::class;
+
+    /**
+     * @var Collection
+     */
+    public $models;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Retrieve the People model from an Address model
+        $this->models = $this->modelClass::factory()->count(1000)->create();
+    }
 }

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sfneal\Tracking\Tests\Feature\Queries;
+
+use Sfneal\Tracking\Builders\TrackActionBuilder;
+use Sfneal\Tracking\Models\TrackAction;
+use Sfneal\Tracking\Queries\TrackActionQuery;
+use Sfneal\Tracking\Tests\CreateRequest;
+
+class TrackActionQueryTest extends QueriesTestCase
+{
+    use CreateRequest;
+
+    /**
+     * @var TrackAction
+     */
+    public $modelClass = TrackAction::class;
+
+    /** @test */
+    public function query_without_params()
+    {
+        // Create a request
+        $request = $this->createRequest();
+
+        // Query Builder
+        $builder = (new TrackActionQuery($request))->execute();
+
+        $this->assertInstanceOf(TrackActionBuilder::class, $builder);
+        $this->assertEquals($this->count, $builder->count());
+    }
+}


### PR DESCRIPTION
- cut support for php7.4
- cut relationships brought in from hpa app in `TrackingQuery`
- fix $parameters param to default as null in `TrackingQuery`
- start making query test suite