### PR TITLE
Queries namespace cleanup & test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ All notable changes to `tracking` will be documented in this file
 
 ## 0.3.0 - 2021-04-14
 - cut support for php7.4
-- cut relationships brought in from hpa app in `TrackingQuery`
+- cut relationships brought in from hpa app in `TrackActionQuery`
 - fix $parameters param to default as null in `TrackingQuery`
 - start making query test suite
+
+
+## 0.3.1 - 2021-04-15
+- cut relationships brought in from hpa app in `TrackActivityQuery`
+- improve `TrackAction` & `TrackActivity` database factory definitions
+- add queries feature test suite

--- a/database/factories/TrackActionFactory.php
+++ b/database/factories/TrackActionFactory.php
@@ -26,7 +26,7 @@ class TrackActionFactory extends Factory
     {
         return [
             'action' => $this->faker->randomElement($this->randomAction()),
-            'model_table' => 'people',
+            'model_table' => $this->faker->randomElement(['people', 'address']),
             'model_key' => $this->faker->randomNumber(3),
             'model_changes' => $this->faker->randomElements($this->modelChanges()),
         ];

--- a/database/factories/TrackActivityFactory.php
+++ b/database/factories/TrackActivityFactory.php
@@ -29,7 +29,7 @@ class TrackActivityFactory extends Factory
             'route' => $this->route(),
             'description' => $this->faker->text(),
 
-            'model_table' => 'people',
+            'model_table' => $this->faker->randomElement(['people', 'address']),
             'model_key' => $this->faker->randomNumber(3),
             'model_changes' => $this->faker->randomElements($this->modelChanges()),
 

--- a/src/Queries/Base/TrackingQuery.php
+++ b/src/Queries/Base/TrackingQuery.php
@@ -7,6 +7,8 @@ use Sfneal\Queries\Query;
 
 abstract class TrackingQuery extends Query
 {
+    // todo: improve constructor arguments
+
     /**
      * @var Request|null
      */

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -11,6 +11,7 @@ use Sfneal\Tracking\Queries\Base\TrackingQuery;
 class TrackActionQuery extends TrackingQuery
 {
     // todo: add request validation
+    // todo: add use of sfneal/builders HasRelationships trait
 
     use ParamGetter;
 

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -16,31 +16,19 @@ class TrackActivityQuery extends TrackingQuery
     use ParamGetter;
 
     /**
-     * Relationships that should be eager loaded by default.
-     */
-    private const DEFAULT_RELATIONSHIPS = [
-        'user',
-        'tracking',
-        'plan',
-        'planManagement',
-        'planManagement.plan',
-        'project',
-        'task',
-        'task.project',
-        'taskRecord',
-        'taskRecord.task',
-        'taskRecord.task.project',
-    ];
-
-    /**
      * Retrieve a Query builder.
      *
      * @return TrackActivityBuilder
      */
     protected function builder(): TrackActivityBuilder
     {
-        return TrackActivity::query()
-            ->with($this->relationships ?? self::DEFAULT_RELATIONSHIPS);
+        $builder = TrackActivity::query();
+
+        if ($this->relationships) {
+            $builder->with($this->relationships);
+        }
+
+        return $builder;
     }
 
     /**

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -11,6 +11,7 @@ use Sfneal\Tracking\Queries\Base\TrackingQuery;
 class TrackActivityQuery extends TrackingQuery
 {
     // todo: add request validation
+    // todo: add use of sfneal/builders HasRelationships trait
 
     use ParamGetter;
 

--- a/tests/CreateRequest.php
+++ b/tests/CreateRequest.php
@@ -4,6 +4,7 @@ namespace Sfneal\Tracking\Tests;
 
 use Illuminate\Http\Request;
 
+// todo: add to sfneal/mock-models?
 trait CreateRequest
 {
     /**

--- a/tests/CreateRequest.php
+++ b/tests/CreateRequest.php
@@ -11,11 +11,16 @@ trait CreateRequest
      * Create a Request to be used in test methods.
      *
      * @param array $headers
+     * @param array $parameters
+     * @param array $cookies
+     * @param array $files
+     * @param array $server
+     * @param null $content
      * @return Request
      */
-    protected function createRequest(array $headers = []): Request
+    protected function createRequest(array $headers = [], array $parameters = [], array $cookies = [], array $files = [], array $server = [], $content = null): Request
     {
-        $request = Request::create('/', 'GET', [], [], [], [], []);
+        $request = Request::create('/', 'GET', $parameters, $cookies, $files, $server, $content);
 
         foreach ($headers as $header => $value) {
             $request->headers->set($header, $value);

--- a/tests/Feature/Builders/WhereModelTests.php
+++ b/tests/Feature/Builders/WhereModelTests.php
@@ -45,9 +45,9 @@ trait WhereModelTests
     /** @test */
     public function whereModelTable()
     {
-        $expected = 50;
+        $expected = 25;
 
-        $model_key = $this->modelClass::query()
+        $model_table = $this->modelClass::query()
             ->distinct()
             ->get('model_table')
             ->shuffle()
@@ -55,8 +55,8 @@ trait WhereModelTests
             ->pluck('model_table')
             ->first();
 
-        $count = $this->modelClass::query()->whereModelTable($model_key)->count();
+        $models = $this->modelClass::query()->whereModelTable($model_table)->get();
 
-        $this->assertSame($expected, $count);
+        $this->assertContains($model_table, $models->pluck('model_table'));
     }
 }

--- a/tests/Feature/Queries/QueriesTestCase.php
+++ b/tests/Feature/Queries/QueriesTestCase.php
@@ -4,10 +4,13 @@ namespace Sfneal\Tracking\Tests\Feature\Queries;
 
 use Illuminate\Support\Collection;
 use Sfneal\Tracking\Models\Base\Tracking;
+use Sfneal\Tracking\Tests\CreateRequest;
 use Sfneal\Tracking\Tests\TestCase;
 
 class QueriesTestCase extends TestCase
 {
+    use CreateRequest;
+
     /**
      * @var Tracking
      */

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -33,25 +33,25 @@ class TrackActionQueryTest extends QueriesTestCase
     /** @test */
     public function query_with_table_param()
     {
-        // Table name
-        $table = 'people';
+        // Test each unique table name
+        foreach (TrackAction::query()->distinct()->getFlatArray('model_table') as $table) {
+            // All of `TrackAction` records
+            $records = TrackAction::query()
+                ->where('model_table', '=', $table)
+                ->get();
 
-        // All of `TrackAction` records
-        $records = TrackAction::query()
-            ->where('model_table', '=', $table)
-            ->get();
+            // Create a request
+            $request = $this->createRequest([], [
+                'table' => $table
+            ]);
 
-        // Create a request
-        $request = $this->createRequest([], [
-            'table' => $table
-        ]);
+            // Query Builder
+            $builder = (new TrackActionQuery($request))->execute();
 
-        // Query Builder
-        $builder = (new TrackActionQuery($request))->execute();
-
-        // Execute assertions
-        $this->assertInstanceOf(TrackActionBuilder::class, $builder);
-        $this->assertEquals($records->count(), $builder->count());
-        $this->assertEquals($records, $builder->get());
+            // Execute assertions
+            $this->assertInstanceOf(TrackActionBuilder::class, $builder);
+            $this->assertEquals($records->count(), $builder->count());
+            $this->assertEquals($records, $builder->get());
+        }
     }
 }

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -42,7 +42,7 @@ class TrackActionQueryTest extends QueriesTestCase
 
             // Create a request
             $request = $this->createRequest([], [
-                'table' => $table
+                'table' => $table,
             ]);
 
             // Query Builder
@@ -72,7 +72,7 @@ class TrackActionQueryTest extends QueriesTestCase
 
         // Create a request
         $request = $this->createRequest([], [
-            'key' => $model_key
+            'key' => $model_key,
         ]);
 
         // Query Builder
@@ -97,7 +97,6 @@ class TrackActionQueryTest extends QueriesTestCase
                 ->first()
                 ->model_key;
 
-
             // `TrackAction` records for the $table
             $records = TrackAction::query()
                 ->where('model_table', '=', $table)
@@ -107,7 +106,7 @@ class TrackActionQueryTest extends QueriesTestCase
             // Create a request
             $request = $this->createRequest([], [
                 'table' => $table,
-                'key' => $model_key
+                'key' => $model_key,
             ]);
 
             // Query Builder

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -25,7 +25,33 @@ class TrackActionQueryTest extends QueriesTestCase
         // Query Builder
         $builder = (new TrackActionQuery($request))->execute();
 
+        // Execute assertions
         $this->assertInstanceOf(TrackActionBuilder::class, $builder);
         $this->assertEquals($this->count, $builder->count());
+    }
+
+    /** @test */
+    public function query_with_table_param()
+    {
+        // Table name
+        $table = 'people';
+
+        // All of `TrackAction` records
+        $records = TrackAction::query()
+            ->where('model_table', '=', $table)
+            ->get();
+
+        // Create a request
+        $request = $this->createRequest([], [
+            'table' => $table
+        ]);
+
+        // Query Builder
+        $builder = (new TrackActionQuery($request))->execute();
+
+        // Execute assertions
+        $this->assertInstanceOf(TrackActionBuilder::class, $builder);
+        $this->assertEquals($records->count(), $builder->count());
+        $this->assertEquals($records, $builder->get());
     }
 }

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -5,12 +5,9 @@ namespace Sfneal\Tracking\Tests\Feature\Queries;
 use Sfneal\Tracking\Builders\TrackActionBuilder;
 use Sfneal\Tracking\Models\TrackAction;
 use Sfneal\Tracking\Queries\TrackActionQuery;
-use Sfneal\Tracking\Tests\CreateRequest;
 
 class TrackActionQueryTest extends QueriesTestCase
 {
-    use CreateRequest;
-
     /**
      * @var TrackAction
      */

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -35,7 +35,7 @@ class TrackActionQueryTest extends QueriesTestCase
     {
         // Test each unique table name
         foreach (TrackAction::query()->distinct()->getFlatArray('model_table') as $table) {
-            // All of `TrackAction` records
+            // `TrackAction` records for the $table
             $records = TrackAction::query()
                 ->where('model_table', '=', $table)
                 ->get();
@@ -43,6 +43,71 @@ class TrackActionQueryTest extends QueriesTestCase
             // Create a request
             $request = $this->createRequest([], [
                 'table' => $table
+            ]);
+
+            // Query Builder
+            $builder = (new TrackActionQuery($request))->execute();
+
+            // Execute assertions
+            $this->assertInstanceOf(TrackActionBuilder::class, $builder);
+            $this->assertEquals($records->count(), $builder->count());
+            $this->assertEquals($records, $builder->get());
+        }
+    }
+
+    /** @test */
+    public function query_with_key_param()
+    {
+        // Model Key
+        $model_key = TrackAction::query()
+            ->get('model_key')
+            ->shuffle()
+            ->first()
+            ->model_key;
+
+        // `TrackAction` record for the $model_key
+        $records = TrackAction::query()
+            ->where('model_key', '=', $model_key)
+            ->get();
+
+        // Create a request
+        $request = $this->createRequest([], [
+            'key' => $model_key
+        ]);
+
+        // Query Builder
+        $builder = (new TrackActionQuery($request))->execute();
+
+        // Execute assertions
+        $this->assertInstanceOf(TrackActionBuilder::class, $builder);
+        $this->assertEquals($records->count(), $builder->count());
+        $this->assertEquals($records, $builder->get());
+    }
+
+    /** @test */
+    public function query_with_table_and_key_params()
+    {
+        // Test each unique table name
+        foreach (TrackAction::query()->distinct()->getFlatArray('model_table') as $table) {
+            // Model Key
+            $model_key = TrackAction::query()
+                ->where('model_table', '=', $table)
+                ->get('model_key')
+                ->shuffle()
+                ->first()
+                ->model_key;
+
+
+            // `TrackAction` records for the $table
+            $records = TrackAction::query()
+                ->where('model_table', '=', $table)
+                ->where('model_key', '=', $model_key)
+                ->get();
+
+            // Create a request
+            $request = $this->createRequest([], [
+                'table' => $table,
+                'key' => $model_key
             ]);
 
             // Query Builder

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -8,6 +8,8 @@ use Sfneal\Tracking\Queries\TrackActionQuery;
 
 class TrackActionQueryTest extends QueriesTestCase
 {
+    // todo: add methods to test 'period' key
+
     /**
      * @var TrackAction
      */

--- a/tests/Feature/Queries/TrackActivityQueryTest.php
+++ b/tests/Feature/Queries/TrackActivityQueryTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Sfneal\Tracking\Tests\Feature\Queries;
+
+use Sfneal\Tracking\Builders\TrackActivityBuilder;
+use Sfneal\Tracking\Models\TrackActivity;
+use Sfneal\Tracking\Queries\TrackActivityQuery;
+
+class TrackActivityQueryTest extends QueriesTestCase
+{
+    /**
+     * @var TrackActivity
+     */
+    public $modelClass = TrackActivity::class;
+
+    /** @test */
+    public function query_without_params()
+    {
+        // Create a request
+        $request = $this->createRequest();
+
+        // Query Builder
+        $builder = (new TrackActivityQuery($request))->execute();
+
+        // Execute assertions
+        $this->assertInstanceOf(TrackActivityBuilder::class, $builder);
+        $this->assertEquals($this->count, $builder->count());
+    }
+
+    /** @test */
+    public function query_with_table_param()
+    {
+        // Test each unique table name
+        foreach (TrackActivity::query()->distinct()->getFlatArray('model_table') as $table) {
+            // `TrackAction` records for the $table
+            $records = TrackActivity::query()
+                ->where('model_table', '=', $table)
+                ->get();
+
+            // Create a request
+            $request = $this->createRequest([], [
+                'table' => $table,
+            ]);
+
+            // Query Builder
+            $builder = (new TrackActivityQuery($request))->execute();
+
+            // Execute assertions
+            $this->assertInstanceOf(TrackActivityBuilder::class, $builder);
+            $this->assertEquals($records->count(), $builder->count());
+            $this->assertEquals($records, $builder->get());
+        }
+    }
+
+    /** @test */
+    public function query_with_user_param()
+    {
+        // Test each unique table name
+        foreach (TrackActivity::query()->distinct()->limit(20)->getFlatArray('user_id') as $user_id) {
+            // `TrackAction` records for the $table
+            $records = TrackActivity::query()
+                ->where('user_id', '=', $user_id)
+                ->get();
+
+            // Create a request
+            $request = $this->createRequest([], [
+                'user' => $user_id,
+            ]);
+
+            // Query Builder
+            $builder = (new TrackActivityQuery($request))->execute();
+
+            // Execute assertions
+            $this->assertInstanceOf(TrackActivityBuilder::class, $builder);
+            $this->assertEquals($records->count(), $builder->count());
+            $this->assertEquals($records, $builder->get());
+        }
+    }
+
+    /** @test */
+    public function query_with_users_param()
+    {
+        // Test each unique table name
+        $user_ids = TrackActivity::query()->distinct()->limit(20)->getFlatArray('user_id');
+
+
+        // `TrackAction` records for the $table
+        $records = TrackActivity::query()
+            ->whereIn('user_id', $user_ids)
+            ->get();
+
+        // Create a request
+        $request = $this->createRequest([], [
+            'users' => $user_ids,
+        ]);
+
+        // Query Builder
+        $builder = (new TrackActivityQuery($request))->execute();
+
+        // Execute assertions
+        $this->assertInstanceOf(TrackActivityBuilder::class, $builder);
+        $this->assertEquals($records->count(), $builder->count());
+        $this->assertEquals($records, $builder->get());
+    }
+
+    /** @test */
+    public function query_with_key_param()
+    {
+        // Model Key
+        $model_key = TrackActivity::query()
+            ->get('model_key')
+            ->shuffle()
+            ->first()
+            ->model_key;
+
+        // `TrackAction` record for the $model_key
+        $records = TrackActivity::query()
+            ->where('model_key', '=', $model_key)
+            ->get();
+
+        // Create a request
+        $request = $this->createRequest([], [
+            'key' => $model_key,
+        ]);
+
+        // Query Builder
+        $builder = (new TrackActivityQuery($request))->execute();
+
+        // Execute assertions
+        $this->assertInstanceOf(TrackActivityBuilder::class, $builder);
+        $this->assertEquals($records->count(), $builder->count());
+        $this->assertEquals($records, $builder->get());
+    }
+
+    /** @test */
+    public function query_with_table_and_key_params()
+    {
+        // Test each unique table name
+        foreach (TrackActivity::query()->distinct()->getFlatArray('model_table') as $table) {
+            // Model Key
+            $model_key = TrackActivity::query()
+                ->where('model_table', '=', $table)
+                ->get('model_key')
+                ->shuffle()
+                ->first()
+                ->model_key;
+
+            // `TrackAction` records for the $table
+            $records = TrackActivity::query()
+                ->where('model_table', '=', $table)
+                ->where('model_key', '=', $model_key)
+                ->get();
+
+            // Create a request
+            $request = $this->createRequest([], [
+                'table' => $table,
+                'key' => $model_key,
+            ]);
+
+            // Query Builder
+            $builder = (new TrackActivityQuery($request))->execute();
+
+            // Execute assertions
+            $this->assertInstanceOf(TrackActivityBuilder::class, $builder);
+            $this->assertEquals($records->count(), $builder->count());
+            $this->assertEquals($records, $builder->get());
+        }
+    }
+}

--- a/tests/Feature/Queries/TrackActivityQueryTest.php
+++ b/tests/Feature/Queries/TrackActivityQueryTest.php
@@ -8,6 +8,8 @@ use Sfneal\Tracking\Queries\TrackActivityQuery;
 
 class TrackActivityQueryTest extends QueriesTestCase
 {
+    // todo: add methods to test 'period' key
+
     /**
      * @var TrackActivity
      */

--- a/tests/Feature/Queries/TrackActivityQueryTest.php
+++ b/tests/Feature/Queries/TrackActivityQueryTest.php
@@ -85,7 +85,6 @@ class TrackActivityQueryTest extends QueriesTestCase
         // Test each unique table name
         $user_ids = TrackActivity::query()->distinct()->limit(20)->getFlatArray('user_id');
 
-
         // `TrackAction` records for the $table
         $records = TrackActivity::query()
             ->whereIn('user_id', $user_ids)


### PR DESCRIPTION
- cut relationships brought in from hpa app in `TrackActivityQuery`
- improve `TrackAction` & `TrackActivity` database factory definitions
- add queries feature test suite