### PR TITLE
New unit tests & action/job return type hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,10 @@ All notable changes to `tracking` will be documented in this file
 - cut relationships brought in from hpa app in `TrackActivityQuery`
 - improve `TrackAction` & `TrackActivity` database factory definitions
 - add queries feature test suite
+
+
+## 0.3.2 - 2021-04-15
+- fix issues with `TrackAction`, `TrackActivity` & `TrackTraffic` actions & jobs not returning newly created models
+- fix issues with migrations not allowing columns to be nullable
+- fix min sfneal/laravel-helpers version to ensure `AppInfo::env()` method is supported
+- add unit tests to test suite

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sfneal/array-helpers": "^1.0",
         "sfneal/controllers": "^2.0",
         "sfneal/datum": "^1.0",
-        "sfneal/laravel-helpers": "^2.0",
+        "sfneal/laravel-helpers": "^2.1.1",
         "sfneal/models": "^2.2",
         "sfneal/observables": "^1.0",
         "sfneal/queueables": "^2.0",

--- a/database/migrations/create_track_activity_table.php.stub
+++ b/database/migrations/create_track_activity_table.php.stub
@@ -19,7 +19,7 @@ class CreateTrackActivityTable extends Migration
             $table->increments('track_activity_id');
             $table->integer('user_id');
             $table->string('route', 255);
-            $table->text('description');
+            $table->text('description')->nullable();
             $table->string('model_table');
             $table->integer('model_key');
             $table->string('model_changes')->nullable();

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -76,7 +76,7 @@ class ParseTrafficAction extends Action
     {
         $this->tracking['request']['host'] = $request->getHttpHost();
         $this->tracking['request']['uri'] = $request->getRequestUri();
-        $this->tracking['request']['method'] = strtoupper($request->getMethod());
+        $this->tracking['request']['method'] = $request->getMethod();
         $this->tracking['request']['payload'] = $this->getRequestPayload($request);
         $this->tracking['request']['browser'] = $_SERVER['HTTP_USER_AGENT'] ?? null;
         $this->tracking['request']['ip'] = $request->ip();

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -43,7 +43,7 @@ class ParseTrafficAction extends Action
     ) {
         // Initialize event for serialization
         $this->tracking['user_id'] = intval(auth()->id());
-        $this->tracking['session_id'] = Cookie::get('hpa_laravel_session');
+        $this->tracking['session_id'] = Cookie::get('hpa_laravel_session') ?? session_id();
         $this->tracking['app_version'] = AppInfo::version();
         $this->tracking['time_stamp'] = $this->getTimestamp($time_stamp);
 
@@ -81,7 +81,7 @@ class ParseTrafficAction extends Action
         $this->tracking['request']['browser'] = $_SERVER['HTTP_USER_AGENT'] ?? null;
         $this->tracking['request']['ip'] = $request->ip();
         $this->tracking['request']['referrer'] = $_SERVER['HTTP_REFERER'] ?? null;
-        $this->tracking['request']['token'] = $request->get('track_traffic_token');
+        $this->tracking['request']['token'] = $request->get('track_traffic_token') ?? uniqid();
     }
 
     /**

--- a/src/Actions/TrackActionAction.php
+++ b/src/Actions/TrackActionAction.php
@@ -29,11 +29,11 @@ class TrackActionAction extends Action
     /**
      * Track a user's activity/actions.
      *
-     * @return void
+     * @return TrackAction|Model
      */
-    public function execute()
+    public function execute(): TrackAction
     {
-        TrackAction::query()->create([
+        return TrackAction::query()->create([
             'action'        => $this->action,
             'model_table'   => $this->model->getTable(),
             'model_key'     => $this->model->getKey(),

--- a/src/Actions/TrackActivityAction.php
+++ b/src/Actions/TrackActivityAction.php
@@ -44,11 +44,11 @@ class TrackActivityAction extends Action
     /**
      * Track a user's activity/actions.
      *
-     * @return void
+     * @return TrackActivity|Model
      */
-    public function execute()
+    public function execute(): TrackActivity
     {
-        TrackActivity::query()->create([
+        return TrackActivity::query()->create([
             'user_id'       => $this->user_id,
             'route'         => $this->route,
             'description'   => $this->description,

--- a/src/Actions/TrackTrafficAction.php
+++ b/src/Actions/TrackTrafficAction.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Tracking\Actions;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 use Sfneal\Actions\Action;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
@@ -28,18 +29,19 @@ class TrackTrafficAction extends Action
     /**
      * Retrieve tracking data and then do something with it.
      *
-     * @return void
+     * @return TrackTraffic|Model
      */
-    public function execute()
+    public function execute(): ?TrackTraffic
     {
-        // Store traffic data in database
-        if (config('tracking.traffic.store')) {
-            TrackTraffic::query()->create($this->tracking);
-        }
-
         // Log JSON encoded activity to local log file
         if (config('tracking.traffic.log')) {
             Log::channel(config('tracking.traffic.log_channel'))->info(json_encode($this->tracking));
         }
+
+        // Store traffic data in database
+        if (config('tracking.traffic.store')) {
+            return TrackTraffic::query()->create($this->tracking);
+        }
+        return null;
     }
 }

--- a/src/Actions/TrackTrafficAction.php
+++ b/src/Actions/TrackTrafficAction.php
@@ -42,6 +42,7 @@ class TrackTrafficAction extends Action
         if (config('tracking.traffic.store')) {
             return TrackTraffic::query()->create($this->tracking);
         }
+
         return null;
     }
 }

--- a/src/Jobs/TrackActionJob.php
+++ b/src/Jobs/TrackActionJob.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Sfneal\Queueables\Job;
 use Sfneal\Tracking\Actions\TrackActionAction;
+use Sfneal\Tracking\Models\TrackAction;
 
 class TrackActionJob extends Job
 {
@@ -47,17 +48,13 @@ class TrackActionJob extends Job
     /**
      * Execute the job.
      *
-     * @return void
+     * @return TrackAction|Model|null
      */
-    public function handle()
+    public function handle(): ?TrackAction
     {
         if ($this->model->exists) {
-            (new TrackActionAction(
-                $this->action,
-                $this->model,
-                $this->model_changes
-            )
-            )->execute();
+            return (new TrackActionAction($this->action, $this->model, $this->model_changes))->execute();
         }
+        return null;
     }
 }

--- a/src/Jobs/TrackActionJob.php
+++ b/src/Jobs/TrackActionJob.php
@@ -55,6 +55,7 @@ class TrackActionJob extends Job
         if ($this->model->exists) {
             return (new TrackActionAction($this->action, $this->model, $this->model_changes))->execute();
         }
+
         return null;
     }
 }

--- a/src/Jobs/TrackActivityJob.php
+++ b/src/Jobs/TrackActivityJob.php
@@ -5,6 +5,7 @@ namespace Sfneal\Tracking\Jobs;
 use Illuminate\Database\Eloquent\Model;
 use Sfneal\Queueables\Job;
 use Sfneal\Tracking\Actions\TrackActivityAction;
+use Sfneal\Tracking\Models\TrackActivity;
 
 class TrackActivityJob extends Job
 {
@@ -48,11 +49,11 @@ class TrackActivityJob extends Job
     /**
      * Execute the job.
      *
-     * @return void
+     * @return TrackActivity|Model
      */
-    public function handle()
+    public function handle(): TrackActivity
     {
-        (new TrackActivityAction(
+        return (new TrackActivityAction(
             $this->model,
             $this->request_token,
             $this->user_id,

--- a/src/Models/TrackTraffic.php
+++ b/src/Models/TrackTraffic.php
@@ -101,4 +101,14 @@ class TrackTraffic extends Tracking
     {
         $this->attributes['app_environment'] = $value ?? AppInfo::env();
     }
+
+    /**
+     * Set the 'request_method' attribute.
+     *
+     * @param string|null $value
+     */
+    public function setRequestMethodAttribute(string $value = null)
+    {
+        $this->attributes['request_method'] = strtoupper($value);
+    }
 }

--- a/tests/CrudModelTest.php
+++ b/tests/CrudModelTest.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Sfneal\Tracking\Tests;
+
+
+// todo: add to sfneal/mock-models?
+interface CrudModelTest
+{
+    /** @test */
+    public function records_can_be_created();
+
+    /** @test */
+    public function records_can_be_updated();
+
+    /** @test */
+    public function records_can_be_deleted();
+}

--- a/tests/CrudModelTest.php
+++ b/tests/CrudModelTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Tests;
-
 
 // todo: add to sfneal/mock-models?
 interface CrudModelTest

--- a/tests/EnableMiddleware.php
+++ b/tests/EnableMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Sfneal\Tracking\Tests;
+
+
+use Illuminate\Support\Facades\Route;
+use Sfneal\Tracking\Middleware\TrackTrafficMiddleware;
+
+trait EnableMiddleware
+{
+    /**
+     * Enable TrackTraffic middleware.
+     *
+     * @return void
+     */
+    protected function enableMiddleware(): void
+    {
+        // Enable middleware
+        Route::middleware(TrackTrafficMiddleware::class)->any('/', function () {
+            return 'OK';
+        });
+    }
+}

--- a/tests/EnableMiddleware.php
+++ b/tests/EnableMiddleware.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Tests;
-
 
 use Illuminate\Support\Facades\Route;
 use Sfneal\Tracking\Middleware\TrackTrafficMiddleware;

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -3,17 +3,17 @@
 namespace Sfneal\Tracking\Tests\Feature;
 
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Route;
 use Sfneal\Tracking\Events\TrackTrafficEvent;
-use Sfneal\Tracking\Middleware\TrackTrafficMiddleware;
 use Sfneal\Tracking\Tests\CreateRequest;
+use Sfneal\Tracking\Tests\EnableMiddleware;
 use Sfneal\Tracking\Tests\EventFaker;
 use Sfneal\Tracking\Tests\TestCase;
 
 class MiddlewareTest extends TestCase
 {
-    use EventFaker;
     use CreateRequest;
+    use EnableMiddleware;
+    use EventFaker;
 
     /**
      * Setup the test environment.
@@ -80,14 +80,6 @@ class MiddlewareTest extends TestCase
         // Assert the Event was pushed
         Event::assertNotDispatched(TrackTrafficEvent::class, function (TrackTrafficEvent $event) {
             return is_null($event->tracking['request']['token']);
-        });
-    }
-
-    private function enableMiddleware(): void
-    {
-        // Enable middleware
-        Route::middleware(TrackTrafficMiddleware::class)->any('/', function () {
-            return 'OK';
         });
     }
 }

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -4,14 +4,12 @@ namespace Sfneal\Tracking\Tests\Feature;
 
 use Illuminate\Support\Facades\Event;
 use Sfneal\Tracking\Events\TrackTrafficEvent;
-use Sfneal\Tracking\Tests\CreateRequest;
 use Sfneal\Tracking\Tests\EnableMiddleware;
 use Sfneal\Tracking\Tests\EventFaker;
 use Sfneal\Tracking\Tests\TestCase;
 
 class MiddlewareTest extends TestCase
 {
-    use CreateRequest;
     use EnableMiddleware;
     use EventFaker;
 

--- a/tests/Unit/TrackActionTest.php
+++ b/tests/Unit/TrackActionTest.php
@@ -20,7 +20,7 @@ class TrackActionTest extends TestCase implements CrudModelTest
 
         $this->assertInstanceOf(TrackAction::class, $trackAction);
         $this->assertSame($action, $trackAction->action);
-        $this->assertSame('people', $trackAction->model_table);
+        $this->assertSame(People::getTableName(), $trackAction->model_table);
         $this->assertEmpty($trackAction->model_changes);
     }
 

--- a/tests/Unit/TrackActionTest.php
+++ b/tests/Unit/TrackActionTest.php
@@ -7,9 +7,10 @@ namespace Sfneal\Tracking\Tests\Unit;
 use Sfneal\Testing\Models\People;
 use Sfneal\Tracking\Jobs\TrackActionJob;
 use Sfneal\Tracking\Models\TrackAction;
+use Sfneal\Tracking\Tests\CrudModelTest;
 use Sfneal\Tracking\Tests\TestCase;
 
-class TrackActionTest extends TestCase
+class TrackActionTest extends TestCase implements CrudModelTest
 {
     /** @test */
     public function records_can_be_created()

--- a/tests/Unit/TrackActionTest.php
+++ b/tests/Unit/TrackActionTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Tests\Unit;
-
 
 use Sfneal\Testing\Models\People;
 use Sfneal\Tracking\Jobs\TrackActionJob;
@@ -32,7 +30,7 @@ class TrackActionTest extends TestCase implements CrudModelTest
 
         $newAction = 'Created the People model.';
         $trackAction->update([
-            'action' => $newAction
+            'action' => $newAction,
         ]);
 
         $this->assertInstanceOf(TrackAction::class, $trackAction);

--- a/tests/Unit/TrackActionTest.php
+++ b/tests/Unit/TrackActionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Sfneal\Tracking\Tests\Unit;
+
+
+use Sfneal\Testing\Models\People;
+use Sfneal\Tracking\Jobs\TrackActionJob;
+use Sfneal\Tracking\Models\TrackAction;
+use Sfneal\Tracking\Tests\TestCase;
+
+class TrackActionTest extends TestCase
+{
+    /** @test */
+    public function records_can_be_created()
+    {
+        $action = 'Created the model.';
+        $trackAction = (new TrackActionJob($action, People::factory()->create()))->handle();
+
+        $this->assertInstanceOf(TrackAction::class, $trackAction);
+        $this->assertSame($action, $trackAction->action);
+        $this->assertSame('people', $trackAction->model_table);
+        $this->assertEmpty($trackAction->model_changes);
+    }
+
+    /** @test */
+    public function records_can_be_updated()
+    {
+        $action = 'Created the model.';
+        $trackAction = (new TrackActionJob($action, People::factory()->create()))->handle();
+
+        $newAction = 'Created the People model.';
+        $trackAction->update([
+            'action' => $newAction
+        ]);
+
+        $this->assertInstanceOf(TrackAction::class, $trackAction);
+        $this->assertSame($newAction, $trackAction->action);
+        $this->assertTrue($trackAction->wasUpdated());
+    }
+
+    /** @test */
+    public function records_can_be_deleted()
+    {
+        $action = 'Created the model.';
+        $trackAction = (new TrackActionJob($action, People::factory()->create()))->handle();
+
+        $trackAction->delete();
+
+        $this->assertInstanceOf(TrackAction::class, $trackAction);
+        $this->assertTrue($trackAction->wasDeleted());
+        $this->assertNull(TrackAction::query()->find($trackAction->getKey()));
+    }
+}

--- a/tests/Unit/TrackActivityTest.php
+++ b/tests/Unit/TrackActivityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+
+namespace Sfneal\Tracking\Tests\Unit;
+
+
+use Sfneal\Testing\Models\People;
+use Sfneal\Tracking\Jobs\TrackActivityJob;
+use Sfneal\Tracking\Models\TrackActivity;
+use Sfneal\Tracking\Tests\CrudModelTest;
+use Sfneal\Tracking\Tests\TestCase;
+
+class TrackActivityTest extends TestCase implements CrudModelTest
+{
+    /** @test */
+    public function records_can_be_created()
+    {
+        $model = People::factory()->create();
+        $user_id = rand(1, 999);
+        $route = 'people.create';
+        $activity = (new TrackActivityJob(
+            $model,
+            uniqid(),
+            $user_id,
+            $route
+        ))->handle();
+
+        $this->assertInstanceOf(TrackActivity::class, $activity);
+        $this->assertSame($user_id, $activity->user_id);
+        $this->assertSame($route, $activity->route);
+        $this->assertNull($activity->description);
+        $this->assertSame(People::getTableName(), $activity->model_table);
+        $this->assertSame($model->getKey(), $activity->model_key);
+        $this->assertEmpty($activity->model_changes);
+    }
+
+    /** @test */
+    public function records_can_be_updated()
+    {
+        $model = People::factory()->create();
+        $user_id = rand(1, 999);
+        $route = 'people.create';
+        $activity = (new TrackActivityJob(
+            $model,
+            uniqid(),
+            $user_id,
+            $route
+        ))->handle();
+
+        $description = 'Updated the People model with latest attributes.';
+        $activity->update([
+            'description' => $description
+        ]);
+
+        $this->assertInstanceOf(TrackActivity::class, $activity);
+        $this->assertSame($description, $activity->description);
+        $this->assertTrue($activity->wasUpdated());
+    }
+
+    /** @test */
+    public function records_can_be_deleted()
+    {
+        $model = People::factory()->create();
+        $user_id = rand(1, 999);
+        $route = 'people.create';
+        $activity = (new TrackActivityJob(
+            $model,
+            uniqid(),
+            $user_id,
+            $route
+        ))->handle();
+
+        $activity->delete();
+
+        $this->assertInstanceOf(TrackActivity::class, $activity);
+        $this->assertTrue($activity->wasDeleted());
+        $this->assertNull(TrackActivity::query()->find($activity->getKey()));
+    }
+}

--- a/tests/Unit/TrackActivityTest.php
+++ b/tests/Unit/TrackActivityTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Tests\Unit;
-
 
 use Sfneal\Testing\Models\People;
 use Sfneal\Tracking\Jobs\TrackActivityJob;
@@ -49,7 +47,7 @@ class TrackActivityTest extends TestCase implements CrudModelTest
 
         $description = 'Updated the People model with latest attributes.';
         $activity->update([
-            'description' => $description
+            'description' => $description,
         ]);
 
         $this->assertInstanceOf(TrackActivity::class, $activity);

--- a/tests/Unit/TrackTrafficTest.php
+++ b/tests/Unit/TrackTrafficTest.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace Sfneal\Tracking\Tests\Unit;
+
+
+use Sfneal\Tracking\Actions\TrackTrafficAction;
+use Sfneal\Tracking\Events\TrackTrafficEvent;
+use Sfneal\Tracking\Models\TrackTraffic;
+use Sfneal\Tracking\Tests\CreateRequest;
+use Sfneal\Tracking\Tests\CrudModelTest;
+use Sfneal\Tracking\Tests\TestCase;
+
+class TrackTrafficTest extends TestCase implements CrudModelTest
+{
+    use CreateRequest;
+
+    /** @test */
+    public function records_can_be_created()
+    {
+        $trackingData = (new TrackTrafficEvent(
+            $this->createRequest(),
+            response('OK'),
+            microtime(true)
+        ))->tracking;
+
+        $traffic = (new TrackTrafficAction($trackingData))->execute();
+
+        $this->assertInstanceOf(TrackTraffic::class, $traffic);
+        $this->assertEquals('testing', $traffic->app_environment);
+        $this->assertEquals('GET', $traffic->request_method);
+    }
+
+    /** @test */
+    public function records_can_be_updated()
+    {
+        $trackingData = (new TrackTrafficEvent(
+            $this->createRequest(),
+            response('OK'),
+            microtime(true)
+        ))->tracking;
+
+        $traffic = (new TrackTrafficAction($trackingData))->execute();
+        $traffic->update([
+            'app_environment' => 'development',
+            'request_method' => 'post',
+        ]);
+
+        $this->assertInstanceOf(TrackTraffic::class, $traffic);
+        $this->assertEquals('development', $traffic->app_environment);
+        $this->assertEquals('POST', $traffic->request_method);
+    }
+
+    /** @test */
+    public function records_can_be_deleted()
+    {
+        $trackingData = (new TrackTrafficEvent(
+            $this->createRequest(),
+            response('OK'),
+            microtime(true)
+        ))->tracking;
+
+        $traffic = (new TrackTrafficAction($trackingData))->execute();
+
+        $traffic->delete();
+
+        $this->assertInstanceOf(TrackTraffic::class, $traffic);
+        $this->assertTrue($traffic->wasDeleted());
+        $this->assertNull(TrackTraffic::query()->find($traffic->getKey()));
+    }
+}

--- a/tests/Unit/TrackTrafficTest.php
+++ b/tests/Unit/TrackTrafficTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Tests\Unit;
-
 
 use Sfneal\Tracking\Actions\TrackTrafficAction;
 use Sfneal\Tracking\Events\TrackTrafficEvent;


### PR DESCRIPTION
 - fix issues with `TrackAction`, `TrackActivity` & `TrackTraffic` actions & jobs not returning newly created models
 - fix issues with migrations not allowing columns to be nullable
 - fix min sfneal/laravel-helpers version to ensure `AppInfo::env()` method is supported
 - add unit tests to test suite