### PR TITLE
New config key values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,11 @@ All notable changes to `tracking` will be documented in this file
 
 ## 0.3.3 - 2021-04-15
 - cut redundant actions & jobs that are only called from a single class
+
+
+## 0.4.0 - 2021-04-15
+- cut use of `session_id()` in `ParseTrafficAction`
+- add use of config 'session.cookie' key for retrieving session id
+- fix issue with 'session_id' column not being nullable
+- add 'tracking.queue' & 'tracking.driver' keys to config file
+- add use of 'tracking.queue' & 'tracking.driver' config keys in `TrackActionJob` & `TrackActivityListener`

--- a/config/tracking.php
+++ b/config/tracking.php
@@ -75,4 +75,28 @@ return [
         'response_content' => env('TRACK_TRAFFIC_RESPONSE_CONTENT', false),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Tracking Jobs Queue
+    |--------------------------------------------------------------------------
+    |
+    | Specify a Job queue to use when dispatching tracking jobs.  Creating a
+    | 'tracking' queue can be effective for avoiding bottlenecks.
+    |
+    | type     : string
+    | default  : 'default'
+    |
+    */
+    'queue' => env('TRACKING_QUEUE', 'default'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Queue Driver
+    |--------------------------------------------------------------------------
+    |
+    | Specify a Queue Driver for dispatching tracking jobs.
+    |
+    */
+    'driver' => env('TRACKING_QUEUE_DRIVER', config('queue.default')),
+
 ];

--- a/database/migrations/create_track_traffic_table.php.stub
+++ b/database/migrations/create_track_traffic_table.php.stub
@@ -18,7 +18,7 @@ class CreateTrackTrafficTable extends Migration
         Schema::create(self::TABLE_NAME, function (Blueprint $table) {
             $table->increments('track_traffic_id');
             $table->integer('user_id');
-            $table->text('session_id');
+            $table->text('session_id')->nullable();
 
             // Application
             $table->text('app_version');

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -43,7 +43,9 @@ class ParseTrafficAction extends Action
     ) {
         // Initialize event for serialization
         $this->tracking['user_id'] = intval(auth()->id());
-        $this->tracking['session_id'] = Cookie::get('hpa_laravel_session') ?? session_id();
+
+        // todo: add config value
+        $this->tracking['session_id'] = Cookie::get('hpa_laravel_session');
         $this->tracking['app_version'] = AppInfo::version();
         $this->tracking['time_stamp'] = $this->getTimestamp($time_stamp);
 

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -43,9 +43,7 @@ class ParseTrafficAction extends Action
     ) {
         // Initialize event for serialization
         $this->tracking['user_id'] = intval(auth()->id());
-
-        // todo: add config value
-        $this->tracking['session_id'] = Cookie::get('hpa_laravel_session');
+        $this->tracking['session_id'] = Cookie::get(config('session.cookie'));
         $this->tracking['app_version'] = AppInfo::version();
         $this->tracking['time_stamp'] = $this->getTimestamp($time_stamp);
 

--- a/src/Jobs/TrackActionJob.php
+++ b/src/Jobs/TrackActionJob.php
@@ -17,12 +17,6 @@ class TrackActionJob extends Job
      */
     public $deleteWhenMissingModels = true;
 
-    // todo: add to config
-    /**
-     * @var string Queue to use
-     */
-    public $queue = 'tracking';
-
     // todo: improve type hinting
     public $action;
     public $model;
@@ -44,6 +38,9 @@ class TrackActionJob extends Job
         } catch (Exception $exception) {
             $this->model_changes = [];
         }
+
+        $this->onQueue(config('tracking.queue'));
+        $this->onConnection(config('tracking.queue_driver'));
     }
 
     /**

--- a/src/Listeners/TrackActivityListener.php
+++ b/src/Listeners/TrackActivityListener.php
@@ -8,11 +8,14 @@ use Sfneal\Tracking\Events\TrackActivityEvent;
 
 class TrackActivityListener extends Listener
 {
-    // todo: add to config
     /**
-     * @var string Queue to use
+     * TrackActivityListener constructor.
      */
-    public $queue = 'tracking';
+    public function __construct()
+    {
+        $this->onQueue(config('tracking.queue'));
+        $this->onConnection(config('tracking.queue_driver'));
+    }
 
     /**
      * Handle the event.


### PR DESCRIPTION
- cut use of `session_id()` in `ParseTrafficAction`
- add use of config 'session.cookie' key for retrieving session id
- fix issue with 'session_id' column not being nullable
- add 'tracking.queue' & 'tracking.driver' keys to config file
- add use of 'tracking.queue' & 'tracking.driver' config keys in `TrackActionJob` & `TrackActivityListener`