### PR TITLE
`ParseTraffic` optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,10 @@ All notable changes to `tracking` will be documented in this file
 - fix issue with 'session_id' column not being nullable
 - add 'tracking.queue' & 'tracking.driver' keys to config file
 - add use of 'tracking.queue' & 'tracking.driver' config keys in `TrackActionJob` & `TrackActivityListener`
+
+
+## 0.5.0 - 2021-04-15
+- refactor `ParseTrafficAction` to `ParseTraffic`
+- fix issue with `ParseTraffic` response time results not being type cast to floats
+- improve parameter & return type hinting TrackTraffic events & actions
+- add public `parse()` methods to `ParseTraffic` to enable use cases where not all data is needed to be retrieved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,5 +59,5 @@ All notable changes to `tracking` will be documented in this file
 ## 0.5.0 - 2021-04-15
 - refactor `ParseTrafficAction` to `ParseTraffic`
 - fix issue with `ParseTraffic` response time results not being type cast to floats
-- improve parameter & return type hinting TrackTraffic events & actions
+- improve parameter & return type hinting
 - add public `parse()` methods to `ParseTraffic` to enable use cases where not all data is needed to be retrieved

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -48,7 +48,7 @@ class ParseTraffic extends Action
      *
      * @param Request                   $request
      * @param Response|RedirectResponse $response
-     * @param string|null                $timestamp
+     * @param string|null               $timestamp
      */
     public function __construct(Request $request, Response $response, string $timestamp = null)
     {
@@ -68,7 +68,7 @@ class ParseTraffic extends Action
         $this->tracking['user_id'] = intval(auth()->id());
         $this->tracking['session_id'] = Cookie::get(config('session.cookie'));
         $this->tracking['app_version'] = AppInfo::version();
-        $this->tracking['time_stamp'] = $this->getTimestamp($this->timestamp);
+        $this->tracking['time_stamp'] = self::getTimestamp($this->timestamp);
 
         // Request data
         $this->parseRequest();
@@ -87,7 +87,7 @@ class ParseTraffic extends Action
      *
      * @return void
      */
-    private function parseRequest(): void
+    protected function parseRequest(): void
     {
         $this->tracking['request']['host'] = $this->request->getHttpHost();
         $this->tracking['request']['uri'] = $this->request->getRequestUri();
@@ -104,10 +104,10 @@ class ParseTraffic extends Action
      *
      * @return void
      */
-    private function parseResponse(): void
+    protected function parseResponse(): void
     {
         $this->tracking['response']['code'] = $this->response->getStatusCode();
-        $this->tracking['response']['time'] = $this->getResponseTime($this->timestamp);
+        $this->tracking['response']['time'] = self::getResponseTime($this->timestamp);
 
         // Store response content served if enabled
         if (config('tracking.traffic.response_content')) {
@@ -120,7 +120,7 @@ class ParseTraffic extends Action
      *
      * @return void
      */
-    private function parseAgent(): void
+    protected function parseAgent(): void
     {
         $agent = new Agent();
 
@@ -147,7 +147,7 @@ class ParseTraffic extends Action
      *
      * @return float
      */
-    private function getResponseTime(string $timestamp): float
+    private static function getResponseTime(string $timestamp): float
     {
         return floatval(number_format($timestamp - LARAVEL_START, 2));
     }
@@ -159,7 +159,7 @@ class ParseTraffic extends Action
      *
      * @return string
      */
-    private function getTimestamp(string $timestamp): string
+    private static function getTimestamp(string $timestamp): string
     {
         return date('Y-m-d H:i:s', $timestamp);
     }

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -88,7 +88,7 @@ class ParseTraffic extends Action
      * @param Response|RedirectResponse $response
      * @param $time_stamp
      */
-    private function parseResponse($response, $time_stamp)
+    private function parseResponse(Response $response, $time_stamp)
     {
         $this->tracking['response']['code'] = $response->getStatusCode();
         $this->tracking['response']['time'] = $this->getResponseTime($time_stamp);
@@ -99,6 +99,9 @@ class ParseTraffic extends Action
         }
     }
 
+    /**
+     * Set user agent data on platform, device & browser.
+     */
     private function parseAgent()
     {
         $agent = new Agent();
@@ -109,6 +112,8 @@ class ParseTraffic extends Action
     }
 
     /**
+     * Retrieve a request payload with exclusions removed.
+     *
      * @param Request $request
      *
      * @return array
@@ -132,6 +137,8 @@ class ParseTraffic extends Action
     }
 
     /**
+     * Retrieve a traffic visit occurred at timestamp.
+     *
      * @param $time_stamp
      *
      * @return string

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -84,8 +84,10 @@ class ParseTraffic extends Action
 
     /**
      * Parse a Request object to retrieve relevant data.
+     *
+     * @return void
      */
-    private function parseRequest()
+    private function parseRequest(): void
     {
         $this->tracking['request']['host'] = $this->request->getHttpHost();
         $this->tracking['request']['uri'] = $this->request->getRequestUri();
@@ -99,8 +101,10 @@ class ParseTraffic extends Action
 
     /**
      * Parse a Response object to retrieve relevant data.
+     *
+     * @return void
      */
-    private function parseResponse()
+    private function parseResponse(): void
     {
         $this->tracking['response']['code'] = $this->response->getStatusCode();
         $this->tracking['response']['time'] = $this->getResponseTime($this->timestamp);
@@ -113,8 +117,10 @@ class ParseTraffic extends Action
 
     /**
      * Set user agent data on platform, device & browser.
+     *
+     * @return void
      */
-    private function parseAgent()
+    private function parseAgent(): void
     {
         $agent = new Agent();
 
@@ -128,7 +134,7 @@ class ParseTraffic extends Action
      *
      * @return array
      */
-    private function getRequestPayload()
+    private function getRequestPayload(): array
     {
         return (new ArrayHelpers(array_merge($this->request->query(), $this->request->input())))
             ->arrayRemoveKeys(self::REQUEST_PAYLOAD_EXCLUSIONS);
@@ -137,24 +143,24 @@ class ParseTraffic extends Action
     /**
      * Determine the amount of time taken to return a response.
      *
-     * @param $time_stamp
+     * @param string $timestamp
      *
      * @return float
      */
-    private function getResponseTime($time_stamp)
+    private function getResponseTime(string $timestamp): float
     {
-        return floatval(number_format($time_stamp - LARAVEL_START, 2));
+        return floatval(number_format($timestamp - LARAVEL_START, 2));
     }
 
     /**
      * Retrieve a traffic visit occurred at timestamp.
      *
-     * @param $time_stamp
+     * @param string $timestamp
      *
      * @return string
      */
-    private function getTimestamp($time_stamp)
+    private function getTimestamp(string $timestamp): string
     {
-        return date('Y-m-d H:i:s', $time_stamp);
+        return date('Y-m-d H:i:s', $timestamp);
     }
 }

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -41,20 +41,20 @@ class ParseTraffic extends Action
     /**
      * @var string
      */
-    private $time_stamp;
+    private $timestamp;
 
     /**
      * Create a new event instance.
      *
      * @param Request                   $request
      * @param Response|RedirectResponse $response
-     * @param string                    $time_stamp todo: add default value
+     * @param string|null                $timestamp
      */
-    public function __construct(Request $request, Response $response, string $time_stamp)
+    public function __construct(Request $request, Response $response, string $timestamp = null)
     {
         $this->request = $request;
         $this->response = $response;
-        $this->time_stamp = $time_stamp;
+        $this->timestamp = $timestamp ?? microtime();
     }
 
     /**
@@ -68,7 +68,7 @@ class ParseTraffic extends Action
         $this->tracking['user_id'] = intval(auth()->id());
         $this->tracking['session_id'] = Cookie::get(config('session.cookie'));
         $this->tracking['app_version'] = AppInfo::version();
-        $this->tracking['time_stamp'] = $this->getTimestamp($this->time_stamp);
+        $this->tracking['time_stamp'] = $this->getTimestamp($this->timestamp);
 
         // Request data
         $this->parseRequest();
@@ -103,7 +103,7 @@ class ParseTraffic extends Action
     private function parseResponse()
     {
         $this->tracking['response']['code'] = $this->response->getStatusCode();
-        $this->tracking['response']['time'] = $this->getResponseTime($this->time_stamp);
+        $this->tracking['response']['time'] = $this->getResponseTime($this->timestamp);
 
         // Store response content served if enabled
         if (config('tracking.traffic.response_content')) {

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -15,20 +15,20 @@ use Sfneal\Helpers\Laravel\AppInfo;
 class ParseTraffic extends Action
 {
     /**
-     * @var array
-     */
-    private $tracking = [];
-
-    /**
      * Array keys to exclude from the 'request_payload' attribute.
      *
      * @var array
      */
-    private $request_payload_exclusions = [
+    private const REQUEST_PAYLOAD_EXCLUSIONS = [
         '_token',
         '_method',
         'password',
     ];
+
+    /**
+     * @var array
+     */
+    private $tracking = [];
 
     /**
      * Create a new event instance.
@@ -116,7 +116,7 @@ class ParseTraffic extends Action
     private function getRequestPayload(Request $request)
     {
         return (new ArrayHelpers(array_merge($request->query(), $request->input())))
-            ->arrayRemoveKeys($this->request_payload_exclusions);
+            ->arrayRemoveKeys(self::REQUEST_PAYLOAD_EXCLUSIONS);
     }
 
     /**

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -11,9 +11,8 @@ use Sfneal\Actions\Action;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Laravel\AppInfo;
 
-// todo: refactor to ParseTraffic
 // todo: optimize execute method
-class ParseTrafficAction extends Action
+class ParseTraffic extends Action
 {
     /**
      * @var array

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -11,6 +11,7 @@ use Sfneal\Actions\Action;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Laravel\AppInfo;
 
+// todo: refactor to ParseTraffic
 class ParseTrafficAction extends Action
 {
     /**

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -36,7 +36,7 @@ class ParseTrafficAction extends Action
      *
      * @param Request                   $request
      * @param Response|RedirectResponse $response
-     * @param string                    $time_stamp
+     * @param string                    $time_stamp todo: add default value
      */
     public function __construct(Request $request, Response $response, string $time_stamp)
     {

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -129,7 +129,7 @@ class ParseTrafficAction extends Action
      */
     private function getResponseTime($time_stamp)
     {
-        return number_format($time_stamp - LARAVEL_START, 2);
+        return floatval(number_format($time_stamp - LARAVEL_START, 2));
     }
 
     /**

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -38,11 +38,8 @@ class ParseTrafficAction extends Action
      * @param Response|RedirectResponse $response
      * @param string                    $time_stamp
      */
-    public function __construct(
-        Request $request,
-        $response,
-        string $time_stamp
-    ) {
+    public function __construct(Request $request, Response $response, string $time_stamp)
+    {
         // Initialize event for serialization
         $this->tracking['user_id'] = intval(auth()->id());
         $this->tracking['session_id'] = Cookie::get(config('session.cookie'));

--- a/src/Actions/ParseTrafficAction.php
+++ b/src/Actions/ParseTrafficAction.php
@@ -12,6 +12,7 @@ use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Laravel\AppInfo;
 
 // todo: refactor to ParseTraffic
+// todo: optimize execute method
 class ParseTrafficAction extends Action
 {
     /**

--- a/src/Actions/TrackActivityAction.php
+++ b/src/Actions/TrackActivityAction.php
@@ -8,12 +8,34 @@ use Sfneal\Tracking\Models\TrackActivity;
 
 class TrackActivityAction extends Action
 {
-    // todo: improve type hinting
+    /**
+     * @var Model
+     */
     public $model;
+
+    /**
+     * @var string|null
+     */
     public $request_token;
+
+    /**
+     * @var int
+     */
     public $user_id;
+
+    /**
+     * @var string|null
+     */
     public $route;
+
+    /**
+     * @var array
+     */
     public $model_changes;
+
+    /**
+     * @var string|null
+     */
     public $description;
 
     /**

--- a/src/Builders/TrackTrafficBuilder.php
+++ b/src/Builders/TrackTrafficBuilder.php
@@ -8,7 +8,6 @@ use Sfneal\Users\Builders\Traits\WhereUser;
 
 class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
 {
-    // todo: improve type hinting
     use WhereUser;
 
     /**
@@ -20,7 +19,7 @@ class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function whereRequestUri(string $uri, string $operator = '=', string $boolean = 'and')
+    public function whereRequestUri(string $uri, string $operator = '=', string $boolean = 'and'): self
     {
         $this->where('request_uri', $operator, $uri, $boolean);
 
@@ -35,7 +34,7 @@ class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function orWhereRequestUri(string $uri, string $operator = '=')
+    public function orWhereRequestUri(string $uri, string $operator = '='): self
     {
         $this->whereRequestUri($uri, $operator, 'or');
 
@@ -51,7 +50,7 @@ class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function whereRequestUriIn(array $uris, string $boolean = 'and', bool $not = false)
+    public function whereRequestUriIn(array $uris, string $boolean = 'and', bool $not = false): self
     {
         $this->whereIn('request_uri', $uris, $boolean, $not);
 
@@ -67,7 +66,7 @@ class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function whereEnvironment(string $environment, string $operator = '=', string $boolean = 'and')
+    public function whereEnvironment(string $environment, string $operator = '=', string $boolean = 'and'): self
     {
         $this->where('app_environment', $operator, $environment, $boolean);
 
@@ -79,7 +78,7 @@ class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function whereEnvironmentProduction()
+    public function whereEnvironmentProduction(): self
     {
         $this->whereEnvironment('production');
 
@@ -91,7 +90,7 @@ class TrackTrafficBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function whereEnvironmentDevelopment()
+    public function whereEnvironmentDevelopment(): self
     {
         $this->whereEnvironment('development');
 

--- a/src/Events/TrackTrafficEvent.php
+++ b/src/Events/TrackTrafficEvent.php
@@ -20,11 +20,10 @@ class TrackTrafficEvent extends Event
      *
      * @param Request                   $request
      * @param Response|RedirectResponse $response
-     * @param string                    $time_stamp
+     * @param string|null               $timestamp
      */
-    public function __construct(Request $request, $response, string $time_stamp)
+    public function __construct(Request $request, Response $response, string $timestamp = null)
     {
-        // todo: refactor timestamp to optional param
-        $this->tracking = (new ParseTraffic($request, $response, $time_stamp))->execute();
+        $this->tracking = (new ParseTraffic($request, $response, $timestamp ?? microtime()))->execute();
     }
 }

--- a/src/Events/TrackTrafficEvent.php
+++ b/src/Events/TrackTrafficEvent.php
@@ -6,7 +6,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Sfneal\Events\Event;
-use Sfneal\Tracking\Actions\ParseTrafficAction;
+use Sfneal\Tracking\Actions\ParseTraffic;
 
 class TrackTrafficEvent extends Event
 {
@@ -25,6 +25,6 @@ class TrackTrafficEvent extends Event
     public function __construct(Request $request, $response, string $time_stamp)
     {
         // todo: refactor timestamp to optional param
-        $this->tracking = (new ParseTrafficAction($request, $response, $time_stamp))->execute();
+        $this->tracking = (new ParseTraffic($request, $response, $time_stamp))->execute();
     }
 }

--- a/src/Jobs/TrackActionJob.php
+++ b/src/Jobs/TrackActionJob.php
@@ -17,9 +17,19 @@ class TrackActionJob extends Job
      */
     public $deleteWhenMissingModels = true;
 
-    // todo: improve type hinting
+    /**
+     * @var string Description of the action.
+     */
     public $action;
+
+    /**
+     * @var Collection|Model Model or models effected by the action
+     */
     public $model;
+
+    /**
+     * @var array array of changes made to the model
+     */
     public $model_changes;
 
     /**

--- a/tests/Unit/ParseTrafficTest.php
+++ b/tests/Unit/ParseTrafficTest.php
@@ -3,7 +3,7 @@
 namespace Sfneal\Tracking\Tests\Unit;
 
 use Illuminate\Http\Response;
-use Sfneal\Tracking\Actions\ParseTrafficAction;
+use Sfneal\Tracking\Actions\ParseTraffic;
 use Sfneal\Tracking\Tests\CreateRequest;
 use Sfneal\Tracking\Tests\TestCase;
 
@@ -39,7 +39,7 @@ class ParseTrafficTest extends TestCase
 
         $this->timeStamp = microtime(true);
         $this->response = response('OK');
-        $this->tracking = (new ParseTrafficAction(
+        $this->tracking = (new ParseTraffic(
             $this->createRequest([], ['page'=>1]),
             $this->response,
             $this->timeStamp

--- a/tests/Unit/ParseTrafficTest.php
+++ b/tests/Unit/ParseTrafficTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Sfneal\Tracking\Tests\Unit;
+
+use Illuminate\Http\Response;
+use Sfneal\Tracking\Actions\ParseTrafficAction;
+use Sfneal\Tracking\Tests\CreateRequest;
+use Sfneal\Tracking\Tests\TestCase;
+
+class ParseTrafficTest extends TestCase
+{
+    use CreateRequest;
+
+    /**
+     * @var float
+     */
+    private $timeStamp;
+
+    /**
+     * @var array
+     */
+    private $tracking;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['config']->set('tracking.traffic.response_content', true);
+
+        $this->timeStamp = microtime(true);
+        $this->response = response('OK');
+        $this->tracking = (new ParseTrafficAction(
+            $this->createRequest([], ['page'=>1]),
+            $this->response,
+            $this->timeStamp
+        ))->execute();
+    }
+
+    /** @test */
+    public function tracking_attributes_are_correct()
+    {
+        $this->assertIsArray($this->tracking);
+        $this->assertIsInt($this->tracking['user_id']);
+        $this->assertIsString($this->tracking['time_stamp']);
+        $this->assertSame(date('Y-m-d H:i:s', $this->timeStamp), $this->tracking['time_stamp']);
+    }
+
+    /** @test  */
+    public function response_content_is_correct()
+    {
+        $this->assertIsString($this->tracking['response']['content']);
+        $this->assertSame($this->response->content(), $this->tracking['response']['content']);
+    }
+
+    /** @test */
+    public function request_attributes_are_correct()
+    {
+        $this->assertIsString($this->tracking['request']['host']);
+        $this->assertStringContainsString('/', $this->tracking['request']['uri']);
+        $this->assertSame('/?page=1', $this->tracking['request']['uri']);
+        $this->assertSame('GET', $this->tracking['request']['method']);
+        $this->assertIsArray($this->tracking['request']['payload']);
+        $this->assertSame(['page'=>1], $this->tracking['request']['payload']);
+        $this->assertIsString($this->tracking['request']['ip']);
+        $this->assertSame('127.0.0.1', $this->tracking['request']['ip']);
+        $this->assertIsString($this->tracking['request']['token']);
+    }
+
+    /** @test */
+    public function response_attributes_are_correct()
+    {
+        $this->assertIsInt($this->tracking['response']['code']);
+        $this->assertSame(200, $this->tracking['response']['code']);
+        $this->assertIsFloat($this->tracking['response']['time']);
+    }
+}

--- a/tests/Unit/ParseTrafficTest.php
+++ b/tests/Unit/ParseTrafficTest.php
@@ -17,9 +17,9 @@ class ParseTrafficTest extends TestCase
     private $timeStamp;
 
     /**
-     * @var array
+     * @var ParseTraffic
      */
-    private $tracking;
+    private $parser;
 
     /**
      * @var Response
@@ -39,48 +39,56 @@ class ParseTrafficTest extends TestCase
 
         $this->timeStamp = microtime(true);
         $this->response = response('OK');
-        $this->tracking = (new ParseTraffic(
+        $this->parser = new ParseTraffic(
             $this->createRequest([], ['page'=>1]),
             $this->response,
             $this->timeStamp
-        ))->execute();
+        );
     }
 
     /** @test */
     public function tracking_attributes_are_correct()
     {
-        $this->assertIsArray($this->tracking);
-        $this->assertIsInt($this->tracking['user_id']);
-        $this->assertIsString($this->tracking['time_stamp']);
-        $this->assertSame(date('Y-m-d H:i:s', $this->timeStamp), $this->tracking['time_stamp']);
+        $tracking = $this->parser->execute();
+
+        $this->assertIsArray($tracking);
+        $this->assertIsInt($tracking['user_id']);
+        $this->assertIsString($tracking['time_stamp']);
+        $this->assertSame(date('Y-m-d H:i:s', $this->timeStamp), $tracking['time_stamp']);
     }
 
     /** @test  */
     public function response_content_is_correct()
     {
-        $this->assertIsString($this->tracking['response']['content']);
-        $this->assertSame($this->response->content(), $this->tracking['response']['content']);
+        $tracking = $this->parser->execute();
+
+        $this->assertIsString($tracking['response']['content']);
+        $this->assertSame($this->response->content(), $tracking['response']['content']);
     }
 
     /** @test */
     public function request_attributes_are_correct()
     {
-        $this->assertIsString($this->tracking['request']['host']);
-        $this->assertStringContainsString('/', $this->tracking['request']['uri']);
-        $this->assertSame('/?page=1', $this->tracking['request']['uri']);
-        $this->assertSame('GET', $this->tracking['request']['method']);
-        $this->assertIsArray($this->tracking['request']['payload']);
-        $this->assertSame(['page'=>1], $this->tracking['request']['payload']);
-        $this->assertIsString($this->tracking['request']['ip']);
-        $this->assertSame('127.0.0.1', $this->tracking['request']['ip']);
-        $this->assertIsString($this->tracking['request']['token']);
+        $tracking = $this->parser->execute();
+
+        $this->assertIsString($tracking['request']['host']);
+        $this->assertStringContainsString('/', $tracking['request']['uri']);
+        $this->assertSame('/?page=1', $tracking['request']['uri']);
+        $this->assertSame('GET', $tracking['request']['method']);
+        $this->assertIsArray($tracking['request']['payload']);
+        $this->assertSame(['page'=>1], $tracking['request']['payload']);
+        $this->assertIsString($tracking['request']['ip']);
+        $this->assertSame('127.0.0.1', $tracking['request']['ip']);
+        $this->assertIsString($tracking['request']['token']);
     }
 
     /** @test */
     public function response_attributes_are_correct()
     {
-        $this->assertIsInt($this->tracking['response']['code']);
-        $this->assertSame(200, $this->tracking['response']['code']);
-        $this->assertIsFloat($this->tracking['response']['time']);
+        $tracking = $this->parser->execute();
+
+        $this->assertIsInt($tracking['response']['code']);
+        $this->assertSame(200, $tracking['response']['code']);
+        $this->assertIsFloat($tracking['response']['time']);
     }
 }

--- a/tests/Unit/ParseTrafficTest.php
+++ b/tests/Unit/ParseTrafficTest.php
@@ -57,38 +57,38 @@ class ParseTrafficTest extends TestCase
         $this->assertSame(date('Y-m-d H:i:s', $this->timeStamp), $tracking['time_stamp']);
     }
 
-    /** @test  */
-    public function response_content_is_correct()
-    {
-        $tracking = $this->parser->execute();
-
-        $this->assertIsString($tracking['response']['content']);
-        $this->assertSame($this->response->content(), $tracking['response']['content']);
-    }
-
     /** @test */
     public function request_attributes_are_correct()
     {
-        $tracking = $this->parser->execute();
+        $requestData = $this->parser->parseRequest();
 
-        $this->assertIsString($tracking['request']['host']);
-        $this->assertStringContainsString('/', $tracking['request']['uri']);
-        $this->assertSame('/?page=1', $tracking['request']['uri']);
-        $this->assertSame('GET', $tracking['request']['method']);
-        $this->assertIsArray($tracking['request']['payload']);
-        $this->assertSame(['page'=>1], $tracking['request']['payload']);
-        $this->assertIsString($tracking['request']['ip']);
-        $this->assertSame('127.0.0.1', $tracking['request']['ip']);
-        $this->assertIsString($tracking['request']['token']);
+        $this->assertIsString($requestData['host']);
+        $this->assertStringContainsString('/', $requestData['uri']);
+        $this->assertSame('/?page=1', $requestData['uri']);
+        $this->assertSame('GET', $requestData['method']);
+        $this->assertIsArray($requestData['payload']);
+        $this->assertSame(['page'=>1], $requestData['payload']);
+        $this->assertIsString($requestData['ip']);
+        $this->assertSame('127.0.0.1', $requestData['ip']);
+        $this->assertIsString($requestData['token']);
+    }
+
+    /** @test  */
+    public function response_parse_content_is_correct()
+    {
+        $responseData = $this->parser->parseResponse();
+
+        $this->assertIsString($responseData['content']);
+        $this->assertSame($this->response->content(), $responseData['content']);
     }
 
     /** @test */
-    public function response_attributes_are_correct()
+    public function response_parse_is_correct()
     {
-        $tracking = $this->parser->execute();
+        $responseData = $this->parser->parseResponse();
 
-        $this->assertIsInt($tracking['response']['code']);
-        $this->assertSame(200, $tracking['response']['code']);
-        $this->assertIsFloat($tracking['response']['time']);
+        $this->assertIsInt($responseData['code']);
+        $this->assertSame(200, $responseData['code']);
+        $this->assertIsFloat($responseData['time']);
     }
 }


### PR DESCRIPTION
 - refactor `ParseTrafficAction` to `ParseTraffic`
 - fix issue with `ParseTraffic` response time results not being type cast to floats
 - improve parameter & return type hinting TrackTraffic events & actions
 - add public `parse()` methods to `ParseTraffic` to enable use cases where not all data is needed to be retrieved