### PR TITLE
`TrackingQuery` constructor params refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,9 @@ All notable changes to `tracking` will be documented in this file
 - add 'models' section to 'tracking' config that allows for overwriting default models with custom extensions
 - add use of `ModelAdapter` for accessing `TrackAction`, `TrackActivity` & `TrackTraffic` models
 - cut `TrackingRelationship` trait and use in models
+
+
+## 0.7.0 - 2021-04-19
+- add testing of `TrackActivity` 'tracking' relationship
+- add use of `HasRelationships` trait to abstract `TrackingQuery`
+- refactor constructor params of `TrackActionQuery` & `TrackActivityQuery` to no longer include $relationships

--- a/database/migrations/create_track_activity_table.php.stub
+++ b/database/migrations/create_track_activity_table.php.stub
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTrackActivityTable extends Migration
 {
-    // todo: add relationship to migration
     private const TABLE_NAME = 'track_activity';
 
     /**

--- a/database/migrations/create_track_activity_table.php.stub
+++ b/database/migrations/create_track_activity_table.php.stub
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTrackActivityTable extends Migration
 {
+    // todo: add relationship to migration
     private const TABLE_NAME = 'track_activity';
 
     /**

--- a/src/Models/TrackActivity.php
+++ b/src/Models/TrackActivity.php
@@ -88,8 +88,6 @@ class TrackActivity extends Tracking
     /**
      * Related TrackTraffic data.
      *
-     * // todo: add tests
-     *
      * @return BelongsTo
      */
     public function tracking()

--- a/src/Queries/Base/TrackingQuery.php
+++ b/src/Queries/Base/TrackingQuery.php
@@ -4,10 +4,11 @@ namespace Sfneal\Tracking\Queries\Base;
 
 use Illuminate\Http\Request;
 use Sfneal\Queries\Query;
+use Sfneal\Queries\Traits\HasRelationships;
 
 abstract class TrackingQuery extends Query
 {
-    // todo: improve constructor arguments
+    use HasRelationships;
 
     /**
      * @var Request|null
@@ -20,20 +21,13 @@ abstract class TrackingQuery extends Query
     protected $parameters;
 
     /**
-     * @var array|null
-     */
-    protected $relationships;
-
-    /**
      * TrackActionQuery constructor.
      * @param Request|null $request
      * @param array|null   $parameters
-     * @param array|null   $relationships
      */
-    public function __construct(Request $request = null, array $parameters = null, array $relationships = null)
+    public function __construct(Request $request = null, array $parameters = null)
     {
         $this->request = $request;
         $this->parameters = $parameters ?? [];
-        $this->relationships = $relationships;
     }
 }

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -23,7 +23,7 @@ class TrackActionQuery extends TrackingQuery
     {
         $builder = ModelAdapter::TrackAction()::query();
 
-        if ($this->relationships) {
+        if (! empty($this->relationships)) {
             $builder->with($this->relationships);
         }
 

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -11,7 +11,6 @@ use Sfneal\Tracking\Utils\ModelAdapter;
 class TrackActionQuery extends TrackingQuery
 {
     // todo: add request validation
-    // todo: add use of sfneal/datum HasRelationships trait
 
     use ParamGetter;
 

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -23,7 +23,7 @@ class TrackActivityQuery extends TrackingQuery
     {
         $builder = ModelAdapter::TrackActivity()::query();
 
-        if ($this->relationships) {
+        if (! empty($this->relationships)) {
             $builder->with($this->relationships);
         }
 

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -11,7 +11,6 @@ use Sfneal\Tracking\Utils\ModelAdapter;
 class TrackActivityQuery extends TrackingQuery
 {
     // todo: add request validation
-    // todo: add use of sfneal/datum HasRelationships trait
 
     use ParamGetter;
 

--- a/tests/Unit/TrackActivityTest.php
+++ b/tests/Unit/TrackActivityTest.php
@@ -4,12 +4,18 @@ namespace Sfneal\Tracking\Tests\Unit;
 
 use Sfneal\Testing\Models\People;
 use Sfneal\Tracking\Actions\TrackActivityAction;
+use Sfneal\Tracking\Actions\TrackTrafficAction;
+use Sfneal\Tracking\Events\TrackTrafficEvent;
 use Sfneal\Tracking\Models\TrackActivity;
+use Sfneal\Tracking\Models\TrackTraffic;
+use Sfneal\Tracking\Tests\CreateRequest;
 use Sfneal\Tracking\Tests\CrudModelTest;
 use Sfneal\Tracking\Tests\TestCase;
 
 class TrackActivityTest extends TestCase implements CrudModelTest
 {
+    use CreateRequest;
+
     /** @test */
     public function records_can_be_created()
     {
@@ -30,6 +36,39 @@ class TrackActivityTest extends TestCase implements CrudModelTest
         $this->assertSame(People::getTableName(), $activity->model_table);
         $this->assertSame($model->getKey(), $activity->model_key);
         $this->assertEmpty($activity->model_changes);
+    }
+
+    /** @test */
+    public function records_can_be_created_with_tracking()
+    {
+        $trackingData = (new TrackTrafficEvent(
+            $this->createRequest(),
+            response('OK'),
+            microtime(true)
+        ))->tracking;
+
+        $traffic = (new TrackTrafficAction($trackingData))->execute();
+
+        $model = People::factory()->create();
+        $user_id = rand(1, 999);
+        $route = 'people.create';
+        $activity = (new TrackActivityAction(
+            $model,
+            $traffic->request_token,
+            $user_id,
+            $route
+        ))->execute();
+
+        $this->assertInstanceOf(TrackActivity::class, $activity);
+        $this->assertSame($user_id, $activity->user_id);
+        $this->assertSame($route, $activity->route);
+        $this->assertNull($activity->description);
+        $this->assertSame(People::getTableName(), $activity->model_table);
+        $this->assertSame($model->getKey(), $activity->model_key);
+        $this->assertEmpty($activity->model_changes);
+
+        $this->assertInstanceOf(TrackTraffic::class, $activity->tracking);
+        $this->assertSame($traffic->request_token, $activity->request_token);
     }
 
     /** @test */


### PR DESCRIPTION
- add testing of `TrackActivity` 'tracking' relationship
- add use of `HasRelationships` trait to abstract `TrackingQuery`
- refactor constructor params of `TrackActionQuery` & `TrackActivityQuery` to no longer include $relationships