### PR TITLE
`TrackRequest` request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,10 @@ All notable changes to `tracking` will be documented in this file
 
 ## 0.8.1 - 2021-04-20
 - optimize queries test suite
+
+
+## 0.9.0 - 2021-04-21
+- make `TrackRequest` for validating `TrackActivityQuery` & `TrackActionQuery` request params
+- add use of `TrackRequest` validation in `TrackingQuery` constructor
+- fix issue with $model_key not returning an integer in `query_with_table_and_key_params()` test methods
+

--- a/src/Queries/Base/TrackingQuery.php
+++ b/src/Queries/Base/TrackingQuery.php
@@ -2,16 +2,16 @@
 
 namespace Sfneal\Tracking\Queries\Base;
 
-use Illuminate\Http\Request;
 use Sfneal\Queries\Query;
 use Sfneal\Queries\Traits\HasRelationships;
+use Sfneal\Tracking\Requests\TrackRequest;
 
 abstract class TrackingQuery extends Query
 {
     use HasRelationships;
 
     /**
-     * @var Request|null
+     * @var TrackRequest|null
      */
     protected $request;
 
@@ -22,10 +22,10 @@ abstract class TrackingQuery extends Query
 
     /**
      * TrackActionQuery constructor.
-     * @param Request|null $request
+     * @param TrackRequest|null $request
      * @param array|null   $parameters
      */
-    public function __construct(Request $request = null, array $parameters = null)
+    public function __construct(TrackRequest $request = null, array $parameters = null)
     {
         $this->request = $request;
         $this->parameters = $parameters ?? [];

--- a/src/Queries/Base/TrackingQuery.php
+++ b/src/Queries/Base/TrackingQuery.php
@@ -29,5 +29,10 @@ abstract class TrackingQuery extends Query
     {
         $this->request = $request;
         $this->parameters = $parameters ?? [];
+
+        // Merge validated request inputs with parameters
+        if ($validated = $this->request->validated()) {
+            $this->parameters = array_merge($this->parameters, $validated);
+        }
     }
 }

--- a/src/Queries/TrackActionQuery.php
+++ b/src/Queries/TrackActionQuery.php
@@ -10,8 +10,6 @@ use Sfneal\Tracking\Utils\ModelAdapter;
 
 class TrackActionQuery extends TrackingQuery
 {
-    // todo: add request validation
-
     use ParamGetter;
 
     /**

--- a/src/Queries/TrackActivityQuery.php
+++ b/src/Queries/TrackActivityQuery.php
@@ -10,8 +10,6 @@ use Sfneal\Tracking\Utils\ModelAdapter;
 
 class TrackActivityQuery extends TrackingQuery
 {
-    // todo: add request validation
-
     use ParamGetter;
 
     /**

--- a/src/Requests/TrackRequest.php
+++ b/src/Requests/TrackRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+
+namespace Sfneal\Tracking\Requests;
+
+
+use Illuminate\Foundation\Http\FormRequest;
+
+// todo: add to controllers package?
+class TrackRequest extends FormRequest
+{
+    /**
+     * TrackRequest constructor.
+     *
+     * @param array                $query      The GET parameters
+     * @param array                $request    The POST parameters
+     * @param array                $attributes The request attributes (parameters parsed from the PATH_INFO, ...)
+     * @param array                $cookies    The COOKIE parameters
+     * @param array                $files      The FILES parameters
+     * @param array                $server     The SERVER parameters
+     * @param string|resource|null $content    The raw body data
+     */
+    public function __construct(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null)
+    {
+        parent::__construct($query, $request, $attributes, $cookies, $files, $server, $content);
+
+        // Set container
+        $this->setContainer(app());
+
+        // Get validator instance
+        $this->getValidatorInstance();
+    }
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'table' => ['string', 'nullable'],
+            'user' => ['integer', 'nullable'],
+            'users' => ['array', 'nullable'],
+            'key' => ['integer', 'nullable'],
+            'period' => ['array', 'nullable'],
+        ];
+    }
+}

--- a/src/Requests/TrackRequest.php
+++ b/src/Requests/TrackRequest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Tracking\Requests;
-
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/Feature/Queries/QueriesTestCase.php
+++ b/tests/Feature/Queries/QueriesTestCase.php
@@ -4,14 +4,12 @@ namespace Sfneal\Tracking\Tests\Feature\Queries;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Sfneal\Testing\Utils\Traits\CreateRequest;
 use Sfneal\Tracking\Models\Base\Tracking;
+use Sfneal\Tracking\Requests\TrackRequest;
 use Sfneal\Tracking\Tests\TestCase;
 
 class QueriesTestCase extends TestCase
 {
-    use CreateRequest;
-
     /**
      * @var Tracking
      */
@@ -38,6 +36,33 @@ class QueriesTestCase extends TestCase
 
         // Retrieve the People model from an Address model
         $this->models = $this->modelClass::factory()->count($this->count)->create();
+    }
+
+    /**
+     * Create a Request to be used in test methods.
+     *
+     * @param array $headers
+     * @param array $parameters
+     * @param array $cookies
+     * @param array $files
+     * @param array $server
+     * @param null $content
+     * @return TrackRequest
+     */
+    protected function createRequest(array $headers = [],
+                                     array $parameters = [],
+                                     array $cookies = [],
+                                     array $files = [],
+                                     array $server = [],
+                                     $content = null): TrackRequest
+    {
+        $request = TrackRequest ::create('/', 'GET', $parameters, $cookies, $files, $server, $content);
+
+        foreach ($headers as $header => $value) {
+            $request->headers->set($header, $value);
+        }
+
+        return $request;
     }
 
     /**

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -9,8 +9,6 @@ use Sfneal\Tracking\Queries\TrackActionQuery;
 
 class TrackActionQueryTest extends QueriesTestCase
 {
-    // todo: add methods to test 'period' key
-
     /**
      * @var TrackAction
      */
@@ -117,8 +115,7 @@ class TrackActionQueryTest extends QueriesTestCase
 
         // `TrackAction` record for the $model_key
         $records = TrackAction::query()
-            ->where('created_at', '>=', $min)
-            ->where('created_at', '<=', $max)
+            ->whereBetween('created_at', [$min, $max])
             ->get();
 
         // Create a request

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -90,7 +90,13 @@ class TrackActionQueryTest extends QueriesTestCase
             ->values()
             ->each(function (string $table) {
                 // Model Key
-                $model_key = (new RandomModelAttributeQuery(TrackAction::class, 'model_table'))->execute();
+                $model_key = TrackAction::query()
+                    ->whereModelTable($table)
+                    ->get('model_key')
+                    ->shuffle()
+                    ->take(1)
+                    ->pluck('model_key')
+                    ->first();
 
                 // `TrackAction` records for the $table
                 $records = TrackAction::query()

--- a/tests/Feature/Queries/TrackActionQueryTest.php
+++ b/tests/Feature/Queries/TrackActionQueryTest.php
@@ -34,23 +34,27 @@ class TrackActionQueryTest extends QueriesTestCase
     public function query_with_table_param()
     {
         // Test each unique table name
-        foreach (TrackAction::query()->distinct()->getFlatArray('model_table') as $table) {
-            // `TrackAction` records for the $table
-            $records = TrackAction::query()
-                ->where('model_table', '=', $table)
-                ->get();
+        TrackAction::query()
+            ->distinct()
+            ->pluck('model_table')
+            ->values()
+            ->each(function (string $table) {
+                // `TrackAction` records for the $table
+                $records = TrackAction::query()
+                    ->where('model_table', '=', $table)
+                    ->get();
 
-            // Create a request
-            $request = $this->createRequest([], [
-                'table' => $table,
-            ]);
+                // Create a request
+                $request = $this->createRequest([], [
+                    'table' => $table,
+                ]);
 
-            // Query Builder
-            $builder = (new TrackActionQuery($request))->execute();
+                // Query Builder
+                $builder = (new TrackActionQuery($request))->execute();
 
-            // Execute assertions
-            $this->executeAssertions($records, $builder, TrackActionBuilder::class);
-        }
+                // Execute assertions
+                $this->executeAssertions($records, $builder, TrackActionBuilder::class);
+            });
     }
 
     /** @test */
@@ -80,28 +84,32 @@ class TrackActionQueryTest extends QueriesTestCase
     public function query_with_table_and_key_params()
     {
         // Test each unique table name
-        foreach (TrackAction::query()->distinct()->getFlatArray('model_table') as $table) {
-            // Model Key
-            $model_key = (new RandomModelAttributeQuery(TrackAction::class, 'model_table'))->execute();
+        TrackAction::query()
+            ->distinct()
+            ->pluck('model_table')
+            ->values()
+            ->each(function (string $table) {
+                // Model Key
+                $model_key = (new RandomModelAttributeQuery(TrackAction::class, 'model_table'))->execute();
 
-            // `TrackAction` records for the $table
-            $records = TrackAction::query()
-                ->where('model_table', '=', $table)
-                ->where('model_key', '=', $model_key)
-                ->get();
+                // `TrackAction` records for the $table
+                $records = TrackAction::query()
+                    ->where('model_table', '=', $table)
+                    ->where('model_key', '=', $model_key)
+                    ->get();
 
-            // Create a request
-            $request = $this->createRequest([], [
-                'table' => $table,
-                'key' => $model_key,
-            ]);
+                // Create a request
+                $request = $this->createRequest([], [
+                    'table' => $table,
+                    'key' => $model_key,
+                ]);
 
-            // Query Builder
-            $builder = (new TrackActionQuery($request))->execute();
+                // Query Builder
+                $builder = (new TrackActionQuery($request))->execute();
 
-            // Execute assertions
-            $this->executeAssertions($records, $builder, TrackActionBuilder::class);
-        }
+                // Execute assertions
+                $this->executeAssertions($records, $builder, TrackActionBuilder::class);
+            });
     }
 
     /** @test */

--- a/tests/Feature/Queries/TrackActivityQueryTest.php
+++ b/tests/Feature/Queries/TrackActivityQueryTest.php
@@ -34,46 +34,55 @@ class TrackActivityQueryTest extends QueriesTestCase
     public function query_with_table_param()
     {
         // Test each unique table name
-        foreach (TrackActivity::query()->distinct()->getFlatArray('model_table') as $table) {
-            // `TrackAction` records for the $table
-            $records = TrackActivity::query()
-                ->where('model_table', '=', $table)
-                ->get();
+        TrackActivity::query()
+            ->distinct()
+            ->pluck('model_table')
+            ->values()
+            ->each(function (string $table) {
+                // `TrackAction` records for the $table
+                $records = TrackActivity::query()
+                    ->where('model_table', '=', $table)
+                    ->get();
 
-            // Create a request
-            $request = $this->createRequest([], [
-                'table' => $table,
-            ]);
+                // Create a request
+                $request = $this->createRequest([], [
+                    'table' => $table,
+                ]);
 
-            // Query Builder
-            $builder = (new TrackActivityQuery($request))->execute();
+                // Query Builder
+                $builder = (new TrackActivityQuery($request))->execute();
 
-            // Execute assertions
-            $this->executeAssertions($records, $builder, TrackActivityBuilder::class);
-        }
+                // Execute assertions
+                $this->executeAssertions($records, $builder, TrackActivityBuilder::class);
+            });
     }
 
     /** @test */
     public function query_with_user_param()
     {
         // Test each unique table name
-        foreach (TrackActivity::query()->distinct()->limit(20)->getFlatArray('user_id') as $user_id) {
-            // `TrackAction` records for the $table
-            $records = TrackActivity::query()
-                ->where('user_id', '=', $user_id)
-                ->get();
+        TrackActivity::query()
+            ->distinct()
+            ->limit(20)
+            ->pluck('user_id')
+            ->values()
+            ->each(function (int $user_id) {
+                // `TrackAction` records for the $table
+                $records = TrackActivity::query()
+                    ->where('user_id', '=', $user_id)
+                    ->get();
 
-            // Create a request
-            $request = $this->createRequest([], [
-                'user' => $user_id,
-            ]);
+                // Create a request
+                $request = $this->createRequest([], [
+                    'user' => $user_id,
+                ]);
 
-            // Query Builder
-            $builder = (new TrackActivityQuery($request))->execute();
+                // Query Builder
+                $builder = (new TrackActivityQuery($request))->execute();
 
-            // Execute assertions
-            $this->executeAssertions($records, $builder, TrackActivityBuilder::class);
-        }
+                // Execute assertions
+                $this->executeAssertions($records, $builder, TrackActivityBuilder::class);
+            });
     }
 
     /** @test */

--- a/tests/Feature/Queries/TrackActivityQueryTest.php
+++ b/tests/Feature/Queries/TrackActivityQueryTest.php
@@ -137,7 +137,13 @@ class TrackActivityQueryTest extends QueriesTestCase
         // Test each unique table name
         foreach (TrackActivity::query()->distinct()->getFlatArray('model_table') as $table) {
             // Model Key
-            $model_key = (new RandomModelAttributeQuery(TrackActivity::class, 'model_table'))->execute();
+            $model_key = TrackActivity::query()
+                ->whereModelTable($table)
+                ->get('model_key')
+                ->shuffle()
+                ->take(1)
+                ->pluck('model_key')
+                ->first();
 
             // `TrackAction` records for the $table
             $records = TrackActivity::query()

--- a/tests/Feature/Queries/TrackActivityQueryTest.php
+++ b/tests/Feature/Queries/TrackActivityQueryTest.php
@@ -9,8 +9,6 @@ use Sfneal\Tracking\Queries\TrackActivityQuery;
 
 class TrackActivityQueryTest extends QueriesTestCase
 {
-    // todo: add methods to test 'period' key
-
     /**
      * @var TrackActivity
      */
@@ -163,8 +161,7 @@ class TrackActivityQueryTest extends QueriesTestCase
 
         // `TrackAction` record for the $model_key
         $records = TrackActivity::query()
-            ->where('created_at', '>=', $min)
-            ->where('created_at', '<=', $max)
+            ->whereBetween('created_at', [$min, $max])
             ->get();
 
         // Create a request


### PR DESCRIPTION
- make `TrackRequest` for validating `TrackActivityQuery` & `TrackActionQuery` request params
- add use of `TrackRequest` validation in `TrackingQuery` constructor
- fix issue with $model_key not returning an integer in `query_with_table_and_key_params()` test methods