### PR TITLE
`TrackTrafficMiddleware` response creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,3 +135,7 @@ All notable changes to `tracking` will be documented in this file
 ## 1.0.0 - 2021-05-05
 - initial production release
 - bump sfneal/users min version v1.0
+
+
+## 1.0.1 - 2021-05-06
+- fix issue with `TrackTrafficMiddleware` creating the $response before adding the 'track_traffic_token' attribute to the $request

--- a/src/Middleware/TrackTrafficMiddleware.php
+++ b/src/Middleware/TrackTrafficMiddleware.php
@@ -18,16 +18,13 @@ class TrackTrafficMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        // Create response
-        $response = $next($request);
-
         // Check if traffic tracking is enabled
         if (config('tracking.traffic.track')) {
             // Add unique ID to be used to relate traffic & activities
             $request->attributes->add(['track_traffic_token' => uniqid()]);
 
             // Fire Traffic Tracker event
-            event(new TrackTrafficEvent($request, $response, microtime(true)));
+            event(new TrackTrafficEvent($request, $next($request), microtime(true)));
         }
 
         // false value signifies that the tracking token was disabled
@@ -36,6 +33,6 @@ class TrackTrafficMiddleware
         }
 
         // Return the response
-        return $response;
+        return $next($request);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,8 @@ class TestCase extends OrchestraTestCase
 {
     use RefreshDatabase;
 
+    // todo: refactor database seeding to use seeder classes
+
     /**
      * Register package service providers.
      *


### PR DESCRIPTION
- fix issue with `TrackTrafficMiddleware` creating the $response before adding the 'track_traffic_token' attribute to the $request