### PR TITLE
sfneal/array-helpers v2.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,3 +152,4 @@ All notable changes to `tracking` will be documented in this file
 
 ## 1.0.4 - 2021-08-03
 - bump min sfneal/array-helpers version to v2.0 & refactor use
+- add explicit sfneal/address composer requirement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,7 @@ All notable changes to `tracking` will be documented in this file
 ## 1.0.3 - 2021-05-10
 - bump sfneal/controllers min package version to v2.1
 - add use of `Middleware` interface implementation in `TrackTrafficMiddleware` middleware
+
+
+## 1.0.4 - 2021-08-03
+- bump min sfneal/array-helpers version to v2.0 & refactor use

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-json": "*",
         "jenssegers/agent": "^2.6",
         "sfneal/actions": "^2.0",
-        "sfneal/array-helpers": "^1.0",
+        "sfneal/array-helpers": "^2.0",
         "sfneal/controllers": "^2.1",
         "sfneal/datum": "^1.5",
         "sfneal/laravel-helpers": "^2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ext-json": "*",
         "jenssegers/agent": "^2.6",
         "sfneal/actions": "^2.0",
+        "sfneal/address": "^1.2.9",
         "sfneal/array-helpers": "^2.0",
         "sfneal/controllers": "^2.1",
         "sfneal/datum": "^1.5",

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -146,7 +146,7 @@ class ParseTraffic extends Action
     private function getRequestPayload(): array
     {
         return (new ArrayHelpers(array_merge($this->request->query(), $this->request->input())))
-            ->arrayRemoveKeys(self::REQUEST_PAYLOAD_EXCLUSIONS);
+            ->removeKeys(self::REQUEST_PAYLOAD_EXCLUSIONS);
     }
 
     /**

--- a/src/Actions/TrackTrafficAction.php
+++ b/src/Actions/TrackTrafficAction.php
@@ -24,7 +24,7 @@ class TrackTrafficAction extends Action
     public function __construct(array $tracking)
     {
         // Flatten tracking data
-        $this->tracking = (new ArrayHelpers($tracking))->arrayFlattenKeys();
+        $this->tracking = (new ArrayHelpers($tracking))->flattenKeys();
     }
 
     /**


### PR DESCRIPTION
- bump min sfneal/array-helpers version to v2.0 & refactor use
- add explicit sfneal/address composer requirement