### PR TITLE
sfneal/array-helpers v3.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,3 +153,7 @@ All notable changes to `tracking` will be documented in this file
 ## 1.0.4 - 2021-08-03
 - bump min sfneal/array-helpers version to v2.0 & refactor use
 - add explicit sfneal/address composer requirement
+
+
+## 1.0.5 - 2021-08-04
+- bump min sfneal/array-helpers version to v3.0 & refactor use

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "jenssegers/agent": "^2.6",
         "sfneal/actions": "^2.0",
         "sfneal/address": "^1.2.9",
-        "sfneal/array-helpers": "^2.0",
+        "sfneal/array-helpers": "^3.0",
         "sfneal/controllers": "^2.1",
         "sfneal/datum": "^1.5",
         "sfneal/laravel-helpers": "^2.1.1",

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -145,7 +145,7 @@ class ParseTraffic extends Action
      */
     private function getRequestPayload(): array
     {
-        return (new ArrayHelpers(array_merge($this->request->query(), $this->request->input())))
+        return ArrayHelpers::from(array_merge($this->request->query(), $this->request->input()))
             ->removeKeys(self::REQUEST_PAYLOAD_EXCLUSIONS);
     }
 

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -146,7 +146,8 @@ class ParseTraffic extends Action
     private function getRequestPayload(): array
     {
         return ArrayHelpers::from(array_merge($this->request->query(), $this->request->input()))
-            ->removeKeys(self::REQUEST_PAYLOAD_EXCLUSIONS);
+            ->removeKeys(self::REQUEST_PAYLOAD_EXCLUSIONS)
+            ->get();
     }
 
     /**

--- a/src/Actions/TrackTrafficAction.php
+++ b/src/Actions/TrackTrafficAction.php
@@ -24,7 +24,7 @@ class TrackTrafficAction extends Action
     public function __construct(array $tracking)
     {
         // Flatten tracking data
-        $this->tracking = ArrayHelpers::from($tracking)->flattenKeys();
+        $this->tracking = ArrayHelpers::from($tracking)->flattenKeys()->get();
     }
 
     /**

--- a/src/Actions/TrackTrafficAction.php
+++ b/src/Actions/TrackTrafficAction.php
@@ -24,7 +24,7 @@ class TrackTrafficAction extends Action
     public function __construct(array $tracking)
     {
         // Flatten tracking data
-        $this->tracking = (new ArrayHelpers($tracking))->flattenKeys();
+        $this->tracking = ArrayHelpers::from($tracking)->flattenKeys();
     }
 
     /**


### PR DESCRIPTION
- bump min sfneal/array-helpers version to v3.0 & refactor use