### PR TITLE
sfneal/mock-models min dev requirements to v0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,3 +157,8 @@ All notable changes to `tracking` will be documented in this file
 
 ## 1.0.5 - 2021-08-04
 - bump min sfneal/array-helpers version to v3.0 & refactor use
+
+ 
+## 1.0.6 - 2021-08-04
+- bump sfneal/mock-models min dev requirements to v0.9
+- refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "phpunit/phpunit": ">=9.0",
         "orchestra/testbench": ">=6.7.1",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.6"
+        "sfneal/mock-models": ">=0.9"
     },
     "extra": {
         "laravel": {

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -145,6 +145,7 @@ class ParseTraffic extends Action
      */
     private function getRequestPayload(): array
     {
+        // todo: add use of `merge()` method
         return ArrayHelpers::from(array_merge($this->request->query(), $this->request->input()))
             ->removeKeys(self::REQUEST_PAYLOAD_EXCLUSIONS)
             ->get();

--- a/tests/Feature/MigrationsTest.php
+++ b/tests/Feature/MigrationsTest.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\Tracking\Tests\Feature;
 
-use Sfneal\Testing\Utils\Traits\ModelAttributeAssertions;
+use Sfneal\Testing\Utils\Traits\AssertModelAttributes;
 use Sfneal\Tracking\Models\TrackAction;
 use Sfneal\Tracking\Models\TrackActivity;
 use Sfneal\Tracking\Models\TrackTraffic;
@@ -10,7 +10,7 @@ use Sfneal\Tracking\Tests\TestCase;
 
 class MigrationsTest extends TestCase
 {
-    use ModelAttributeAssertions;
+    use AssertModelAttributes;
 
     /** @test */
     public function track_action_table_is_accessible()


### PR DESCRIPTION
- bump sfneal/mock-models min dev requirements to v0.9
- refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`