### PR TITLE
sfneal/array-helpers v3.3 upgrade (merge methods)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,3 +162,7 @@ All notable changes to `tracking` will be documented in this file
 ## 1.0.6 - 2021-08-04
 - bump sfneal/mock-models min dev requirements to v0.9
 - refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`
+ 
+ 
+## 1.0.7 - 2021-08-05
+- bump min sfneal/array-helpers version to v3.3 to support use of `merge()` method

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "jenssegers/agent": "^2.6",
         "sfneal/actions": "^2.0",
         "sfneal/address": "^1.2.9",
-        "sfneal/array-helpers": "^3.0",
+        "sfneal/array-helpers": "^3.3",
         "sfneal/controllers": "^2.1",
         "sfneal/datum": "^1.5",
         "sfneal/laravel-helpers": "^2.1.1",

--- a/src/Actions/ParseTraffic.php
+++ b/src/Actions/ParseTraffic.php
@@ -145,8 +145,8 @@ class ParseTraffic extends Action
      */
     private function getRequestPayload(): array
     {
-        // todo: add use of `merge()` method
-        return ArrayHelpers::from(array_merge($this->request->query(), $this->request->input()))
+        return ArrayHelpers::from($this->request->query())
+            ->merge($this->request->input())
             ->removeKeys(self::REQUEST_PAYLOAD_EXCLUSIONS)
             ->get();
     }


### PR DESCRIPTION
- bump min sfneal/array-helpers version to v3.3 to support use of `merge()` method